### PR TITLE
fix changesets publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: npx changeset version
-          publish: npm run release
+          publish: npx changeset publish
           commit: "chore: release"
           title: "[changesets] release"
         env:


### PR DESCRIPTION
use `npx changeset publish` as publish script in changesets action. previously had undefined npm `release` script.

install, build, and test are run in the `prepack` script which is triggered before `npm publish`