### PR TITLE
chore: grant github workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
 
     if: ${{ github.repository_owner == 'lameuler' }}
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
     
     steps:
       - name: Checkout


### PR DESCRIPTION
grant permissions to the auto-generated `GITHUB_TOKEN`