### PR TITLE
Resolve default executablePath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 				"@rollup/plugin-virtual": "^3.0.2",
 				"@types/node": "^22.7.4",
 				"astro": "^4.15.9",
-				"astro-pdf": "*",
 				"cheerio": "^1.0.0",
 				"rollup": "^4.22.4",
 				"vitest": "^2.1.2"

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -2,7 +2,7 @@ import { type AstroIntegration } from 'astro'
 import { launch, type PuppeteerLaunchOptions, type PDFOptions, type Page, type PuppeteerLifeCycleEvent, type Browser, executablePath } from 'puppeteer'
 import { type InstallOptions } from '@puppeteer/browsers'
 import { mkdir } from 'fs/promises'
-import { dirname, resolve } from 'path'
+import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import chalk from 'chalk'
 import { installBrowser, astroPreview, resolvePathname, mergePages, getPageOptions } from './utils'
@@ -143,7 +143,12 @@ export function pdf(options: Options): AstroIntegration {
 }
 
 export async function findOrInstallBrowser(options: Partial<InstallOptions> | boolean | undefined, defaultCacheDir: string, logger: Logger) {
-    const defaultPath = executablePath()
+    let defaultPath: string | null
+    try {
+        defaultPath = executablePath()
+    } catch (e) {
+        defaultPath = null
+    }
     if (options || !defaultPath) {
         logger.info(chalk.dim(`installing browser...`))
         return await installBrowser(typeof options === 'object' ? options : {}, defaultCacheDir)


### PR DESCRIPTION
Handle error from `executablePath()` when no browser is installed in the default `cacheDir`. This will automatically install a browser if no browser is found.