### PR TITLE
force unpack installed browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
 			],
 			"dependencies": {
 				"@changesets/cli": "^2.27.9",
-				"@puppeteer/browsers": "^2.2.3",
+				"@puppeteer/browsers": "^2.4.0",
 				"chalk": "^5.3.0",
-				"puppeteer": "^22.12.1"
+				"puppeteer": "^23.5.3"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.3.0",
@@ -3606,9 +3606,9 @@
 			}
 		},
 		"node_modules/chromium-bidi": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-			"integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+			"integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"mitt": "3.0.1",
@@ -4126,9 +4126,9 @@
 			}
 		},
 		"node_modules/devtools-protocol": {
-			"version": "0.0.1312386",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-			"integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+			"version": "0.0.1342118",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz",
+			"integrity": "sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
@@ -7265,79 +7265,38 @@
 			}
 		},
 		"node_modules/puppeteer": {
-			"version": "22.15.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
-			"integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+			"version": "23.5.3",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.5.3.tgz",
+			"integrity": "sha512-FghmfBsr/UUpe48OiCg1gV3W4vVfQJKjQehbF07SjnQvEpWcvPTah1nykfGWdOQQ1ydJPIXcajzWN7fliCU3zw==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.3.0",
+				"@puppeteer/browsers": "2.4.0",
+				"chromium-bidi": "0.8.0",
 				"cosmiconfig": "^9.0.0",
-				"devtools-protocol": "0.0.1312386",
-				"puppeteer-core": "22.15.0"
+				"devtools-protocol": "0.0.1342118",
+				"puppeteer-core": "23.5.3",
+				"typed-query-selector": "^2.12.0"
 			},
 			"bin": {
-				"puppeteer": "lib/esm/puppeteer/node/cli.js"
+				"puppeteer": "lib/cjs/puppeteer/node/cli.js"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "22.15.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-			"integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+			"version": "23.5.3",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.5.3.tgz",
+			"integrity": "sha512-V58MZD/B3CwkYsqSEQlHKbavMJptF04fzhMdUpiCRCmUVhwZNwSGEPhaiZ1f8I3ABQUirg3VNhXVB6Z1ubHXtQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.3.0",
-				"chromium-bidi": "0.6.3",
-				"debug": "^4.3.6",
-				"devtools-protocol": "0.0.1312386",
+				"@puppeteer/browsers": "2.4.0",
+				"chromium-bidi": "0.8.0",
+				"debug": "^4.3.7",
+				"devtools-protocol": "0.0.1342118",
+				"typed-query-selector": "^2.12.0",
 				"ws": "^8.18.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-			"integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"extract-zip": "^2.0.1",
-				"progress": "^2.0.3",
-				"proxy-agent": "^6.4.0",
-				"semver": "^7.6.3",
-				"tar-fs": "^3.0.6",
-				"unbzip2-stream": "^1.4.3",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/puppeteer/node_modules/@puppeteer/browsers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-			"integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"extract-zip": "^2.0.1",
-				"progress": "^2.0.3",
-				"proxy-agent": "^6.4.0",
-				"semver": "^7.6.3",
-				"tar-fs": "^3.0.6",
-				"unbzip2-stream": "^1.4.3",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
 			},
 			"engines": {
 				"node": ">=18"
@@ -8374,6 +8333,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/typed-query-selector": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+			"license": "MIT"
 		},
 		"node_modules/typesafe-path": {
 			"version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
 	],
 	"dependencies": {
 		"@changesets/cli": "^2.27.9",
-		"@puppeteer/browsers": "^2.2.3",
+		"@puppeteer/browsers": "^2.4.0",
 		"chalk": "^5.3.0",
-		"puppeteer": "^22.12.1"
+		"puppeteer": "^23.5.3"
 	},
 	"peerDependencies": {
 		"astro": "^4.4.4"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,14 +8,14 @@ import { Server } from 'http'
 export async function installBrowser(options: Partial<InstallOptions>, defaultCacheDir: string) {
     const browser = options.browser ?? Browser.CHROME
     const buildId = options.buildId ?? await resolveBuildId(browser, detectBrowserPlatform()!!, 'stable')
-    const installOptions: InstallOptions = {
+    const installOptions: InstallOptions & { unpack: true } = {
         ...options,
         browser,
         buildId,
-        cacheDir: options.cacheDir ?? defaultCacheDir
+        cacheDir: options.cacheDir ?? defaultCacheDir,
+        unpack: true // ensure that browser is unpacked so it can be used
     }
-    // cast to any to handle overloading of install (theres probably a better way to do this)
-    const installed = await install(installOptions as any)
+    const installed = await install(installOptions)
     return installed.executablePath
 }
 


### PR DESCRIPTION
Ensure that `installOptions` always has `unpack: true`. The [`install`](https://pptr.dev/browsers-api/browsers.install) function is overloaded with different signatures depending on the value of `unpack`. `astro-pdf` needs the browser to be unpacked to have an executable path to use the browser.

Upgraded from puppeteer v22 to v23.