### PR TITLE
revert to releasing with github-actions bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: ubuntu-latest
 
         permissions:
+            contents: write
+            pull-requests: write
             id-token: write
 
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                  token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -41,5 +41,5 @@ jobs:
                   commit: 'chore: release'
                   title: '[changesets] release'
               env:
-                  GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
revert to using github-actions bot with the actions auto token to handle releases.

since releasing is an automated process and re-testing the code which has already been tested in the pull request and on push to main is unnecessary.

this means there are no more required status checks