### PR TITLE
3XX handling

### DIFF
--- a/.changeset/brown-experts-dream.md
+++ b/.changeset/brown-experts-dream.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+improves handling of [3XX status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) which are not redirects (e.g. [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304))

--- a/.github/ISSUE_TEMPLATE/0-bug.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug.yml
@@ -1,32 +1,32 @@
 name: Bug Report
 description: File a bug report.
-labels: ["bug"]
+labels: ['bug']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: input
-    attributes:
-      label: astro-pdf version
-      description: Run `npm list astro-pdf` (or equivalent command in your package manager), or check the info output of your build for the version of `astro-pdf` you have installed.
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Astro info
-      description: Run the [`astro info`](https://docs.astro.build/en/reference/cli-reference/#astro-info) command and paste the output here.
-    validations:
-      required: true
-  - type: textarea
-    id: describe-bug
-    attributes:
-      label: Describe the bug
-      description: Please provide a clear description of the issue and the expected behaviour.
-    validations:
-      required: true
-  - type: input
-    id: reproduction
-    attributes:
-      label: Link to reproduction
-      description: If possible please provide a [minimal reproduction](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions) of the issue to help debug your issue and allow the bug to be fixed more quickly.
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!
+    - type: input
+      attributes:
+          label: astro-pdf version
+          description: Run `npm list astro-pdf` (or equivalent command in your package manager), or check the info output of your build for the version of `astro-pdf` you have installed.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Astro info
+          description: Run the [`astro info`](https://docs.astro.build/en/reference/cli-reference/#astro-info) command and paste the output here.
+      validations:
+          required: true
+    - type: textarea
+      id: describe-bug
+      attributes:
+          label: Describe the bug
+          description: Please provide a clear description of the issue and the expected behaviour.
+      validations:
+          required: true
+    - type: input
+      id: reproduction
+      attributes:
+          label: Link to reproduction
+          description: If possible please provide a [minimal reproduction](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions) of the issue to help debug your issue and allow the bug to be fixed more quickly.

--- a/.github/ISSUE_TEMPLATE/1-feature.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature.yml
@@ -1,15 +1,15 @@
 name: Feature Request
 description: Submit a request for a new feature.
-labels: ["enhancement"]
+labels: ['enhancement']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to submit a feature request!
-  - type: textarea
-    id: describe-feature
-    attributes:
-      label: Describe the feature
-      description: Please provide details about the feature like how it works and its use cases. Do also provide code samples if you have an idea of the possible syntax or implementation of the feature.
-    validations:
-      required: true
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to submit a feature request!
+    - type: textarea
+      id: describe-feature
+      attributes:
+          label: Describe the feature
+          description: Please provide details about the feature like how it works and its use cases. Do also provide code samples if you have an idea of the possible syntax or implementation of the feature.
+      validations:
+          required: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default function pdf(options: Options): AstroIntegration {
                 cacheDir = fileURLToPath(config.cacheDir)
             },
             'astro:build:done': async ({ dir, pages, logger }) => {
-                logger.info = logger.info.bind(logger.fork(''))
+                logger.info = logger.fork('').info
 
                 if (typeof cacheDir !== 'string') {
                     logger.error('cacheDir is undefined. ending execution...')
@@ -93,7 +93,7 @@ export default function pdf(options: Options): AstroIntegration {
                     outDir,
                     browser,
                     baseUrl: url,
-                    debug: logger.debug.bind(logger)
+                    debug: (message: string) => logger.debug(message)
                 }
 
                 let count = 0

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -47,7 +47,7 @@ describe('custom server', () => {
                 })
             ]
         })
-    })
+    }, 20_000)
 
     test('close called once', () => {
         expect(close).toHaveBeenCalledOnce()


### PR DESCRIPTION
improves handling of 3XX status codes which are not redirects.

eg `304 Not Modified` which does not have a `Location` header, and would previously fail and log an error redirecting to `/undefined`

will now instead let puppeteer handle them and only fail loads if the status code is 4XX or 5XX