### PR TITLE
organize imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,7 @@
     "semi": false,
     "singleQuote": true,
     "printWidth": 120,
-    "plugins": ["prettier-plugin-organize-imports"]
+    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "importOrder": ["^vitest$", "<THIRD_PARTY_MODULES>", "^astro-pdf(/.*)?$", "^[./]"],
+    "importOrderSeparation": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,6 @@
     "singleQuote": true,
     "printWidth": 120,
     "plugins": ["@trivago/prettier-plugin-sort-imports"],
-    "importOrder": ["^vitest$", "<THIRD_PARTY_MODULES>", "^astro-pdf(/.*)?$", "^[./]"],
+    "importOrder": ["^vitest$", "^node:", "<THIRD_PARTY_MODULES>", "^astro-pdf(/.*)?$", "^[./]"],
     "importOrderSeparation": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
     "tabWidth": 4,
     "semi": false,
     "singleQuote": true,
-    "printWidth": 120
+    "printWidth": 120,
+    "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,34 @@
+// @ts-check
 import pluginJs from '@eslint/js'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import pluginNode from 'eslint-plugin-n'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
-/** @type {import('eslint').Linter.Config} */
-export default [
+export default tseslint.config(
     { files: ['**/*.{js,mjs,cjs,ts}'] },
     { ignores: ['**/dist', 'test/fixtures/**/*.d.ts', 'test/fixtures/**/public', '**/.cache'] },
     { languageOptions: { globals: globals.node } },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,
+    pluginNode.configs['flat/recommended'],
+    {
+        rules: {
+            'n/prefer-node-protocol': 'error',
+            'n/prefer-promises/fs': 'error'
+        }
+    },
+    {
+        files: ['test/*.test.ts'],
+        rules: {
+            'n/no-missing-import': 'off',
+            'n/no-unsupported-features/node-builtins': [
+                'error',
+                {
+                    allowExperimental: true
+                }
+            ]
+        }
+    },
     eslintConfigPrettier
-]
+)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,9 +19,14 @@ export default tseslint.config(
         }
     },
     {
-        files: ['test/*.test.ts'],
+        files: ['test/**'],
         rules: {
-            'n/no-missing-import': 'off',
+            'n/no-missing-import': [
+                'error',
+                {
+                    allowModules: ['astro-pdf']
+                }
+            ],
             'n/no-unsupported-features/node-builtins': [
                 'error',
                 {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-import globals from 'globals'
 import pluginJs from '@eslint/js'
-import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
 
 /** @type {import('eslint').Linter.Config} */
 export default [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "cheerio": "^1.0.0",
                 "eslint": "^9.12.0",
                 "eslint-config-prettier": "^9.1.0",
+                "eslint-plugin-n": "^17.13.2",
                 "glob": "^11.0.0",
                 "globals": "^15.12.0",
                 "pdf2json": "^3.1.4",
@@ -1406,16 +1407,19 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -4909,6 +4913,20 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/enhanced-resolve": {
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/enquirer": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -5104,6 +5122,22 @@
                 }
             }
         },
+        "node_modules/eslint-compat-utils": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+            "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
         "node_modules/eslint-config-prettier": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
@@ -5115,6 +5149,80 @@
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-es-x": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+            "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/ota-meshi",
+                "https://opencollective.com/eslint"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.1.2",
+                "@eslint-community/regexpp": "^4.11.0",
+                "eslint-compat-utils": "^0.5.1"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8"
+            }
+        },
+        "node_modules/eslint-plugin-n": {
+            "version": "17.13.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.13.2.tgz",
+            "integrity": "sha512-MhBAKkT01h8cOXcTBTlpuR7bxH5OBUNpUXefsvwSVEy46cY4m/Kzr2osUCQvA3zJFD6KuCeNNDv0+HDuWk/OcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.1",
+                "enhanced-resolve": "^5.17.1",
+                "eslint-plugin-es-x": "^7.8.0",
+                "get-tsconfig": "^4.8.1",
+                "globals": "^15.11.0",
+                "ignore": "^5.3.2",
+                "minimatch": "^9.0.5",
+                "semver": "^7.6.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.23.0"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/eslint-scope": {
@@ -5702,6 +5810,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+            "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/get-uri": {
@@ -8998,6 +9119,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/restore-cursor": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -9785,6 +9916,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tar-fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "globals": "^15.12.0",
                 "pdf2json": "^3.1.4",
                 "prettier": "^3.3.3",
+                "prettier-plugin-organize-imports": "^4.1.0",
                 "tsup": "^8.3.5",
                 "typescript-eslint": "^8.13.0",
                 "vitest": "^2.1.4"
@@ -8372,6 +8373,23 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/prettier-plugin-organize-imports": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
+            "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "prettier": ">=2.0",
+                "typescript": ">=2.9",
+                "vue-tsc": "^2.1.0"
+            },
+            "peerDependenciesMeta": {
+                "vue-tsc": {
+                    "optional": true
+                }
             }
         },
         "node_modules/prismjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@changesets/changelog-github": "^0.5.0",
                 "@changesets/cli": "^2.27.9",
                 "@eslint/js": "^9.12.0",
+                "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "@types/eslint__js": "^8.42.3",
                 "@types/eslint-config-prettier": "^6.11.3",
                 "@types/node": "^22.7.4",
@@ -33,7 +34,6 @@
                 "globals": "^15.12.0",
                 "pdf2json": "^3.1.4",
                 "prettier": "^3.3.3",
-                "prettier-plugin-organize-imports": "^4.1.0",
                 "tsup": "^8.3.5",
                 "typescript-eslint": "^8.13.0",
                 "vitest": "^2.1.4"
@@ -338,6 +338,46 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/@babel/helper-environment-visitor": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
@@ -376,6 +416,19 @@
             "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2566,6 +2619,158 @@
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "license": "MIT"
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+            "integrity": "sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/generator": "7.17.7",
+                "@babel/parser": "^7.20.5",
+                "@babel/traverse": "7.23.2",
+                "@babel/types": "7.17.0",
+                "javascript-natural-sort": "0.7.1",
+                "lodash": "^4.17.21"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "3.x",
+                "prettier": "2.x - 3.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+            "version": "7.17.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+            "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.17.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/generator": {
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.26.2",
+                "@babel/types": "^7.26.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -6337,6 +6542,13 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/joycon": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -8375,23 +8587,6 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/prettier-plugin-organize-imports": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
-            "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "prettier": ">=2.0",
-                "typescript": ">=2.9",
-                "vue-tsc": "^2.1.0"
-            },
-            "peerDependenciesMeta": {
-                "vue-tsc": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/prismjs": {
             "version": "1.29.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
@@ -9874,6 +10069,16 @@
             },
             "engines": {
                 "node": ">=0.6.0"
+            }
+        },
+        "node_modules/to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.9",
         "@eslint/js": "^9.12.0",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/node": "^22.7.4",
@@ -56,7 +57,6 @@
         "globals": "^15.12.0",
         "pdf2json": "^3.1.4",
         "prettier": "^3.3.3",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "tsup": "^8.3.5",
         "typescript-eslint": "^8.13.0",
         "vitest": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "globals": "^15.12.0",
         "pdf2json": "^3.1.4",
         "prettier": "^3.3.3",
+        "prettier-plugin-organize-imports": "^4.1.0",
         "tsup": "^8.3.5",
         "typescript-eslint": "^8.13.0",
         "vitest": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "cheerio": "^1.0.0",
         "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-n": "^17.13.2",
         "glob": "^11.0.0",
         "globals": "^15.12.0",
         "pdf2json": "^3.1.4",
@@ -67,5 +68,8 @@
     ],
     "publishConfig": {
         "provenance": true
+    },
+    "engines": {
+        "node": ">=18.0.0"
     }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,7 +1,7 @@
-import { detectBrowserPlatform, install, resolveBuildId, Browser, type InstallOptions } from '@puppeteer/browsers'
-import { executablePath } from 'puppeteer'
+import { Browser, detectBrowserPlatform, install, resolveBuildId, type InstallOptions } from '@puppeteer/browsers'
 import { type AstroIntegrationLogger } from 'astro'
 import { dim, yellow } from 'kleur/colors'
+import { executablePath } from 'puppeteer'
 
 export async function installBrowser(options: Partial<InstallOptions>, defaultCacheDir: string) {
     const browser = options.browser ?? Browser.CHROME

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { type AstroConfig, type AstroIntegration } from 'astro'
 import { bgBlue, blue, bold, dim, green, red, yellow } from 'kleur/colors'
 import { launch } from 'puppeteer'
 import { fileURLToPath } from 'url'
+
 import { findOrInstallBrowser } from './browser.js'
 import { defaultPageOptions, getPageOptions, mergePages, type Options, type PageOptions } from './options.js'
 import { PageError, processPage } from './page.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 import { type AstroConfig, type AstroIntegration } from 'astro'
+import { bgBlue, blue, bold, dim, green, red, yellow } from 'kleur/colors'
 import { launch } from 'puppeteer'
 import { fileURLToPath } from 'url'
-import { bgBlue, blue, bold, dim, green, red, yellow } from 'kleur/colors'
-import { astroPreview, type ServerOutput } from './server.js'
-import { defaultPageOptions, getPageOptions, mergePages, type Options, type PageOptions } from './options.js'
 import { findOrInstallBrowser } from './browser.js'
+import { defaultPageOptions, getPageOptions, mergePages, type Options, type PageOptions } from './options.js'
 import { PageError, processPage } from './page.js'
+import { astroPreview, type ServerOutput } from './server.js'
 
-export type { Options, PageOptions }
 export type { PagesEntry, PagesFunction, PagesMap } from './options.js'
 export type { ServerOutput } from './server.js'
+export type { Options, PageOptions }
 
 export default function pdf(options: Options): AstroIntegration {
     let cacheDir: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+import { fileURLToPath } from 'node:url'
+
 import { type AstroConfig, type AstroIntegration } from 'astro'
 import { bgBlue, blue, bold, dim, green, red, yellow } from 'kleur/colors'
 import { launch } from 'puppeteer'
-import { fileURLToPath } from 'url'
 
 import { findOrInstallBrowser } from './browser.js'
 import { defaultPageOptions, getPageOptions, mergePages, type Options, type PageOptions } from './options.js'

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,7 @@
 import type { InstallOptions } from '@puppeteer/browsers'
 import type { AstroConfig } from 'astro'
 import type { Page, PDFOptions, PuppeteerLaunchOptions, PuppeteerLifeCycleEvent } from 'puppeteer'
+
 import type { ServerOutput } from './server.js'
 
 export interface Options {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
+import type { InstallOptions } from '@puppeteer/browsers'
 import type { AstroConfig } from 'astro'
 import type { Page, PDFOptions, PuppeteerLaunchOptions, PuppeteerLifeCycleEvent } from 'puppeteer'
-import type { InstallOptions } from '@puppeteer/browsers'
 import type { ServerOutput } from './server.js'
 
 export interface Options {

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,5 +1,6 @@
-import { mkdir } from 'fs/promises'
-import { dirname } from 'path'
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
 import type { Browser, HTTPRequest, HTTPResponse, Page, PuppeteerLifeCycleEvent } from 'puppeteer'
 
 import { type PageOptions } from './options.js'

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'fs/promises'
 import { dirname } from 'path'
 import type { Browser, HTTPRequest, HTTPResponse, Page, PuppeteerLifeCycleEvent } from 'puppeteer'
+
 import { type PageOptions } from './options.js'
 import { filepathToPathname, openFd, pathnameToFilepath, pipeToFd } from './utils.js'
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,6 +1,6 @@
-import type { Browser, HTTPRequest, HTTPResponse, Page, PuppeteerLifeCycleEvent } from 'puppeteer'
 import { mkdir } from 'fs/promises'
 import { dirname } from 'path'
+import type { Browser, HTTPRequest, HTTPResponse, Page, PuppeteerLifeCycleEvent } from 'puppeteer'
 import { type PageOptions } from './options.js'
 import { filepathToPathname, openFd, pathnameToFilepath, pipeToFd } from './utils.js'
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
+import { Server } from 'node:http'
+import { fileURLToPath } from 'node:url'
+
 import { type AstroConfig, preview } from 'astro'
-import { Server } from 'http'
-import { fileURLToPath } from 'url'
 
 export interface ServerOutput {
     url?: URL

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { open, type FileHandle } from 'fs/promises'
-import { extname, relative, resolve, sep } from 'path'
-import { fileURLToPath, pathToFileURL } from 'url'
+import { open, type FileHandle } from 'node:fs/promises'
+import { extname, relative, resolve, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 export async function openFd(path: string, debug: (message: string) => void) {
     const ext = extname(path)
@@ -22,6 +22,7 @@ export async function openFd(path: string, debug: (message: string) => void) {
     return { fd, path: p }
 }
 
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
 export async function pipeToFd(stream: ReadableStream<Uint8Array>, fd: FileHandle) {
     const writeStream = fd.createWriteStream()
     const reader = stream.getReader()

--- a/test/astro-preview.test.ts
+++ b/test/astro-preview.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, describe, expect, test } from 'vitest'
-import { load } from 'cheerio'
 import { AstroConfig } from 'astro'
-import { pathToFileURL } from 'url'
-import { loadFixture, type TestFixture } from './utils/index.js'
 import { astroPreview, ServerOutput } from 'astro-pdf/dist/server.js'
+import { load } from 'cheerio'
+import { pathToFileURL } from 'url'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { loadFixture, type TestFixture } from './utils/index.js'
 
 let fixture1: TestFixture
 let fixture2: TestFixture

--- a/test/astro-preview.test.ts
+++ b/test/astro-preview.test.ts
@@ -1,8 +1,11 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+
 import { AstroConfig } from 'astro'
-import { astroPreview, ServerOutput } from 'astro-pdf/dist/server.js'
 import { load } from 'cheerio'
 import { pathToFileURL } from 'url'
-import { beforeAll, describe, expect, test } from 'vitest'
+
+import { astroPreview, ServerOutput } from 'astro-pdf/dist/server.js'
+
 import { loadFixture, type TestFixture } from './utils/index.js'
 
 let fixture1: TestFixture

--- a/test/astro-preview.test.ts
+++ b/test/astro-preview.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
+import { pathToFileURL } from 'node:url'
+
 import { AstroConfig } from 'astro'
 import { load } from 'cheerio'
-import { pathToFileURL } from 'url'
 
 import { astroPreview, ServerOutput } from 'astro-pdf/dist/server.js'
 

--- a/test/browser-no-default.test.ts
+++ b/test/browser-no-default.test.ts
@@ -1,10 +1,10 @@
-import { describe, beforeAll, vi, test, expect } from 'vitest'
+import { install } from '@puppeteer/browsers'
+import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 import { existsSync } from 'fs'
 import { mkdir, rm } from 'fs/promises'
 import { fileURLToPath } from 'url'
-import { install } from '@puppeteer/browsers'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { makeLogger } from './utils/index.js'
-import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 
 vi.mock('puppeteer', async (originalImport) => {
     const cacheDir = fileURLToPath(new URL('./fixtures/.cache/browser-no-default/', import.meta.url))

--- a/test/browser-no-default.test.ts
+++ b/test/browser-no-default.test.ts
@@ -1,9 +1,10 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 
+import { existsSync } from 'node:fs'
+import { mkdir, rm } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
 import { install } from '@puppeteer/browsers'
-import { existsSync } from 'fs'
-import { mkdir, rm } from 'fs/promises'
-import { fileURLToPath } from 'url'
 
 import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 

--- a/test/browser-no-default.test.ts
+++ b/test/browser-no-default.test.ts
@@ -1,9 +1,12 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+
 import { install } from '@puppeteer/browsers'
-import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 import { existsSync } from 'fs'
 import { mkdir, rm } from 'fs/promises'
 import { fileURLToPath } from 'url'
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
+
 import { makeLogger } from './utils/index.js'
 
 vi.mock('puppeteer', async (originalImport) => {

--- a/test/build-pdf.test.ts
+++ b/test/build-pdf.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, beforeAll, expect } from 'vitest'
-import { loadFixture, type TestFixture } from './utils/index.js'
-import { resolve } from 'path'
-import { readFile, rm } from 'fs/promises'
 import { existsSync } from 'fs'
+import { readFile, rm } from 'fs/promises'
+import { resolve } from 'path'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { loadFixture, type TestFixture } from './utils/index.js'
 
 describe('build', () => {
     let fixture: TestFixture

--- a/test/build-pdf.test.ts
+++ b/test/build-pdf.test.ts
@@ -1,8 +1,8 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
-import { existsSync } from 'fs'
-import { readFile, rm } from 'fs/promises'
-import { resolve } from 'path'
+import { existsSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
+import { resolve } from 'node:path'
 
 import { loadFixture, type TestFixture } from './utils/index.js'
 

--- a/test/build-pdf.test.ts
+++ b/test/build-pdf.test.ts
@@ -1,7 +1,9 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+
 import { existsSync } from 'fs'
 import { readFile, rm } from 'fs/promises'
 import { resolve } from 'path'
-import { beforeAll, describe, expect, test } from 'vitest'
+
 import { loadFixture, type TestFixture } from './utils/index.js'
 
 describe('build', () => {

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -1,10 +1,13 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+
 import { AstroConfig, AstroIntegrationLogger } from 'astro'
-import pdf from 'astro-pdf'
 import { existsSync } from 'fs'
 import { readdir, readFile, rm } from 'fs/promises'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import pdf from 'astro-pdf'
+
 import { loadFixture, makeLogger, parsePdf, type TestFixture } from './utils/index.js'
 import { start } from './utils/server.js'
 

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
+import { existsSync } from 'node:fs'
+import { readdir, readFile, rm } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { AstroConfig, AstroIntegrationLogger } from 'astro'
-import { existsSync } from 'fs'
-import { readdir, readFile, rm } from 'fs/promises'
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
 
 import pdf from 'astro-pdf'
 

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -1,12 +1,12 @@
-import { describe, test, beforeAll, expect, vi, afterAll } from 'vitest'
 import { AstroConfig, AstroIntegrationLogger } from 'astro'
-import { resolve } from 'path'
-import { readdir, readFile, rm } from 'fs/promises'
+import pdf from 'astro-pdf'
 import { existsSync } from 'fs'
+import { readdir, readFile, rm } from 'fs/promises'
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { loadFixture, makeLogger, parsePdf, type TestFixture } from './utils/index.js'
 import { start } from './utils/server.js'
-import pdf from 'astro-pdf'
-import { fileURLToPath } from 'url'
 
 describe('custom server', () => {
     let fixture: TestFixture

--- a/test/fixtures/build-pdf/astro.config.mjs
+++ b/test/fixtures/build-pdf/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config'
 import astroPdf from 'astro-pdf'
+import { defineConfig } from 'astro/config'
 
 // https://astro.build/config
 export default defineConfig({

--- a/test/fixtures/build-pdf/astro.config.mjs
+++ b/test/fixtures/build-pdf/astro.config.mjs
@@ -1,5 +1,6 @@
-import astroPdf from 'astro-pdf'
 import { defineConfig } from 'astro/config'
+
+import astroPdf from 'astro-pdf'
 
 // https://astro.build/config
 export default defineConfig({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,4 +7,4 @@ test('default exports function', async () => {
 })
 
 // check all documented types
-export type { Options, ServerOutput, PageOptions, PagesEntry, PagesFunction, PagesMap } from 'astro-pdf'
+export type { Options, PageOptions, PagesEntry, PagesFunction, PagesMap, ServerOutput } from 'astro-pdf'

--- a/test/install-browser.test.ts
+++ b/test/install-browser.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+
 import {
     Browser,
     BrowserPlatform,
@@ -5,12 +7,13 @@ import {
     getInstalledBrowsers,
     resolveBuildId
 } from '@puppeteer/browsers'
-import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 import { existsSync } from 'fs'
 import { access, constants, mkdir, rm } from 'fs/promises'
 import { isAbsolute } from 'path'
 import { fileURLToPath } from 'url'
-import { beforeAll, describe, expect, test } from 'vitest'
+
+import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
+
 import { makeLogger } from './utils/index.js'
 
 describe('install browser', () => {

--- a/test/install-browser.test.ts
+++ b/test/install-browser.test.ts
@@ -1,8 +1,3 @@
-import { beforeAll, describe, expect, test } from 'vitest'
-import { existsSync } from 'fs'
-import { access, constants, mkdir, rm } from 'fs/promises'
-import { isAbsolute } from 'path'
-import { fileURLToPath } from 'url'
 import {
     Browser,
     BrowserPlatform,
@@ -10,8 +5,13 @@ import {
     getInstalledBrowsers,
     resolveBuildId
 } from '@puppeteer/browsers'
-import { makeLogger } from './utils/index.js'
 import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
+import { existsSync } from 'fs'
+import { access, constants, mkdir, rm } from 'fs/promises'
+import { isAbsolute } from 'path'
+import { fileURLToPath } from 'url'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { makeLogger } from './utils/index.js'
 
 describe('install browser', () => {
     const cacheDir = fileURLToPath(new URL('./fixtures/.cache/install-browser/', import.meta.url))

--- a/test/install-browser.test.ts
+++ b/test/install-browser.test.ts
@@ -1,5 +1,10 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
+import { existsSync, constants } from 'node:fs'
+import { access, mkdir, rm } from 'node:fs/promises'
+import { isAbsolute } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import {
     Browser,
     BrowserPlatform,
@@ -7,10 +12,6 @@ import {
     getInstalledBrowsers,
     resolveBuildId
 } from '@puppeteer/browsers'
-import { existsSync } from 'fs'
-import { access, constants, mkdir, rm } from 'fs/promises'
-import { isAbsolute } from 'path'
-import { fileURLToPath } from 'url'
 
 import { findOrInstallBrowser } from 'astro-pdf/dist/browser.js'
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,11 +1,11 @@
-import { beforeAll, describe, expect, test } from 'vitest'
 import { AstroConfig, AstroIntegration } from 'astro'
-import { Logger, makeLogger, parsePdf } from './utils/index.js'
-import { cp, lstat, mkdir, rm } from 'fs/promises'
-import { fileURLToPath } from 'url'
-import { existsSync } from 'fs'
-import { resolve } from 'path'
 import pdf from 'astro-pdf'
+import { existsSync } from 'fs'
+import { cp, lstat, mkdir, rm } from 'fs/promises'
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { Logger, makeLogger, parsePdf } from './utils/index.js'
 
 describe('run integration', () => {
     let integration: AstroIntegration

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,10 +1,13 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+
 import { AstroConfig, AstroIntegration } from 'astro'
-import pdf from 'astro-pdf'
 import { existsSync } from 'fs'
 import { cp, lstat, mkdir, rm } from 'fs/promises'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { beforeAll, describe, expect, test } from 'vitest'
+
+import pdf from 'astro-pdf'
+
 import { Logger, makeLogger, parsePdf } from './utils/index.js'
 
 describe('run integration', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,10 +1,11 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
+import { existsSync } from 'node:fs'
+import { cp, lstat, mkdir, rm } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { AstroConfig, AstroIntegration } from 'astro'
-import { existsSync } from 'fs'
-import { cp, lstat, mkdir, rm } from 'fs/promises'
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
 
 import pdf from 'astro-pdf'
 

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, beforeAll, afterAll } from 'vitest'
-import { start } from './utils/server.js'
-import { Browser, launch } from 'puppeteer'
-import { Server } from 'http'
 import { loadPage, PageError } from 'astro-pdf/dist/page.js'
+import { Server } from 'http'
+import { Browser, launch } from 'puppeteer'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { start } from './utils/server.js'
 
 describe('load errors', () => {
     let server: Server

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
-import { Server } from 'http'
+import { Server } from 'node:http'
+
 import { Browser, launch } from 'puppeteer'
 
 import { loadPage, PageError } from 'astro-pdf/dist/page.js'

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -1,7 +1,10 @@
-import { loadPage, PageError } from 'astro-pdf/dist/page.js'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
 import { Server } from 'http'
 import { Browser, launch } from 'puppeteer'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { loadPage, PageError } from 'astro-pdf/dist/page.js'
+
 import { start } from './utils/server.js'
 
 describe('load errors', () => {

--- a/test/page-options.test.ts
+++ b/test/page-options.test.ts
@@ -1,5 +1,6 @@
-import { CleanedMap, defaultPageOptions, getPageOptions, mergePages, PagesFunction } from 'astro-pdf/dist/options.js'
 import { beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { CleanedMap, defaultPageOptions, getPageOptions, mergePages, PagesFunction } from 'astro-pdf/dist/options.js'
 
 describe('merge pages', () => {
     test('pages map', () => {

--- a/test/page-options.test.ts
+++ b/test/page-options.test.ts
@@ -1,5 +1,5 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { CleanedMap, defaultPageOptions, getPageOptions, mergePages, PagesFunction } from 'astro-pdf/dist/options.js'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 
 describe('merge pages', () => {
     test('pages map', () => {

--- a/test/pathname-filepath.test.ts
+++ b/test/pathname-filepath.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
-import { resolve, sep } from 'path'
-import { pathToFileURL } from 'url'
+import { resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { filepathToPathname, pathnameToFilepath } from 'astro-pdf/dist/utils.js'
 

--- a/test/pathname-filepath.test.ts
+++ b/test/pathname-filepath.test.ts
@@ -1,7 +1,9 @@
-import { filepathToPathname, pathnameToFilepath } from 'astro-pdf/dist/utils.js'
+import { describe, expect, test } from 'vitest'
+
 import { resolve, sep } from 'path'
 import { pathToFileURL } from 'url'
-import { describe, expect, test } from 'vitest'
+
+import { filepathToPathname, pathnameToFilepath } from 'astro-pdf/dist/utils.js'
 
 function createTests(name: string, resolveRoot: (root: string) => string | URL, slash = '/') {
     const d = resolveRoot

--- a/test/pathname-filepath.test.ts
+++ b/test/pathname-filepath.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from 'vitest'
-import { pathToFileURL } from 'url'
-import { resolve, sep } from 'path'
 import { filepathToPathname, pathnameToFilepath } from 'astro-pdf/dist/utils.js'
+import { resolve, sep } from 'path'
+import { pathToFileURL } from 'url'
+import { describe, expect, test } from 'vitest'
 
 function createTests(name: string, resolveRoot: (root: string) => string | URL, slash = '/') {
     const d = resolveRoot

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -1,15 +1,15 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
-import { Server } from 'http'
+import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
+import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'
 import { existsSync } from 'fs'
 import { lstat, rm } from 'fs/promises'
+import { Server } from 'http'
 import { resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { Output } from 'pdf2json'
 import { launch, Page } from 'puppeteer'
+import { fileURLToPath } from 'url'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { parsePdf } from './utils/index.js'
 import { start } from './utils/server.js'
-import { Output } from 'pdf2json'
-import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'
-import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
 
 describe('process page', () => {
     let server: Server

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -1,5 +1,5 @@
-import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
-import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+
 import { existsSync } from 'fs'
 import { lstat, rm } from 'fs/promises'
 import { Server } from 'http'
@@ -7,7 +7,10 @@ import { resolve } from 'path'
 import { Output } from 'pdf2json'
 import { launch, Page } from 'puppeteer'
 import { fileURLToPath } from 'url'
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
+import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'
+
 import { parsePdf } from './utils/index.js'
 import { start } from './utils/server.js'
 

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -1,12 +1,13 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 
-import { existsSync } from 'fs'
-import { lstat, rm } from 'fs/promises'
-import { Server } from 'http'
-import { resolve } from 'path'
+import { existsSync } from 'node:fs'
+import { lstat, rm } from 'node:fs/promises'
+import { Server } from 'node:http'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { Output } from 'pdf2json'
 import { launch, Page } from 'puppeteer'
-import { fileURLToPath } from 'url'
 
 import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
 import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,5 +1,5 @@
-import * as path from 'path'
 import { type AstroInlineConfig, AstroIntegrationLogger, build, preview, type PreviewServer } from 'astro'
+import * as path from 'path'
 import PDFParser, { Output } from 'pdf2json'
 import { Mock, vi } from 'vitest'
 

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,7 +1,8 @@
 import { Mock, vi } from 'vitest'
 
+import * as path from 'node:path'
+
 import { type AstroInlineConfig, AstroIntegrationLogger, build, preview, type PreviewServer } from 'astro'
-import * as path from 'path'
 import PDFParser, { Output } from 'pdf2json'
 
 export interface TestFixture {

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,7 +1,8 @@
+import { Mock, vi } from 'vitest'
+
 import { type AstroInlineConfig, AstroIntegrationLogger, build, preview, type PreviewServer } from 'astro'
 import * as path from 'path'
 import PDFParser, { Output } from 'pdf2json'
-import { Mock, vi } from 'vitest'
 
 export interface TestFixture {
     root: string

--- a/test/utils/server.ts
+++ b/test/utils/server.ts
@@ -1,7 +1,7 @@
-import { readFile, stat } from 'fs/promises'
-import { IncomingMessage, Server, ServerResponse } from 'http'
-import { extname, sep } from 'path'
-import { fileURLToPath } from 'url'
+import { readFile, stat } from 'node:fs/promises'
+import { IncomingMessage, Server, ServerResponse } from 'node:http'
+import { extname, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export interface Redirects {
     [src: string]: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'fs/promises'
+import { readFile } from 'node:fs/promises'
+
 import { glob } from 'glob'
 import { defineConfig } from 'tsup'
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsup'
 import { readFile } from 'fs/promises'
 import { glob } from 'glob'
+import { defineConfig } from 'tsup'
 
 const pkg = JSON.parse(await readFile('package.json', 'utf8'))
 


### PR DESCRIPTION
- organize imports with [`@trivago/prettier-plugin-sort-imports`](https://github.com/trivago/prettier-plugin-sort-imports)
- added [`eslint-plugin-n`](https://github.com/eslint-community/eslint-plugin-n)