### PR TITLE
support astro v5 and puppeteer changes

### DIFF
--- a/.changeset/chilly-camels-explain.md
+++ b/.changeset/chilly-camels-explain.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+Fixes check for default browser executable when using Puppeteer ^23.10.0

--- a/.changeset/selfish-lies-speak.md
+++ b/.changeset/selfish-lies-speak.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+Adds support for Astro v5.0. Upgrading to Astro v5.0 should have no impact on compatibility with `astro-pdf`.

--- a/.changeset/wet-pigs-tap.md
+++ b/.changeset/wet-pigs-tap.md
@@ -1,0 +1,10 @@
+---
+'astro-pdf': minor
+---
+
+Bumped `puppeteer` to 23.10.1. Updated to use the new merged [`LaunchOptions`](https://pptr.dev/api/puppeteer.launchoptions) type. This should have no impact on compatibility unless you are manually defining the types of your options, in which case you may need to update to the latest version of puppeteer and replace the `PuppeteerLaunchOptions` type with the `LaunchOptions` type if you get type errors.
+
+```diff
+- import type { PuppeteerLaunchOptions } from 'puppeteer'
++ import type { LaunchOptions } from 'puppeteer'
+```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ export interface Options
 
     See [Configuring Puppeteer](#configuring-puppeteer) for more information.
 
-- **`launch`**: [`PuppeteerLaunchOptions`](https://pptr.dev/api/puppeteer.puppeteerlaunchoptions) _(optional)_
+- **`launch`**: [`LaunchOptions`](https://pptr.dev/api/puppeteer.launchoptions) _(optional)_
 
     Options to pass to Puppeteer [`launch`](https://pptr.dev/api/puppeteer.puppeteernode.launch) for launching the browser.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,37 +13,37 @@
                 "./test/fixtures/**"
             ],
             "dependencies": {
-                "@puppeteer/browsers": "^2.4.0",
+                "@puppeteer/browsers": "^2.5.0",
                 "kleur": "^4.1.5",
-                "puppeteer": "^23.5.3"
+                "puppeteer": "^23.10.1"
             },
             "devDependencies": {
                 "@changesets/changelog-github": "^0.5.0",
                 "@changesets/cli": "^2.27.10",
-                "@eslint/js": "^9.15.0",
+                "@eslint/js": "^9.16.0",
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "@types/eslint__js": "^8.42.3",
                 "@types/eslint-config-prettier": "^6.11.3",
-                "@types/node": "^22.10.0",
-                "@vitest/coverage-istanbul": "^2.1.5",
-                "astro": "^4.16.14",
+                "@types/node": "^22.10.1",
+                "@vitest/coverage-istanbul": "^2.1.8",
+                "astro": "^5.0.3",
                 "cheerio": "^1.0.0",
-                "eslint": "^9.15.0",
+                "eslint": "^9.16.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-n": "^17.14.0",
                 "glob": "^11.0.0",
-                "globals": "^15.12.0",
+                "globals": "^15.13.0",
                 "pdf2json": "^3.1.4",
-                "prettier": "^3.4.0",
+                "prettier": "^3.4.2",
                 "tsup": "^8.3.5",
-                "typescript-eslint": "^8.16.0",
-                "vitest": "^2.1.5"
+                "typescript-eslint": "^8.17.0",
+                "vitest": "^2.1.8"
             },
             "engines": {
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "astro": "^4.4.4"
+                "astro": "^4.4.4 || ^5.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -79,29 +79,43 @@
                 "typescript": "^5.0.0"
             }
         },
-        "node_modules/@astrojs/check/node_modules/@astrojs/language-server": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.0.tgz",
-            "integrity": "sha512-wJHSjGApm5X8Rg1GvkevoatZBfvaFizY4kCPvuSYgs3jGCobuY3KstJGKC1yNLsRJlDweHruP+J54iKn9vEKoA==",
+        "node_modules/@astrojs/compiler": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
+            "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@astrojs/internal-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.2.tgz",
+            "integrity": "sha512-EdDWkC3JJVcpGpqJAU/5hSk2LKXyG3mNGkzGoAuyK+xoPHbaVdSuIWoN1QTnmK3N/gGfaaAfM8gO2KDCAW7S3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@astrojs/language-server": {
+            "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.4.tgz",
+            "integrity": "sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@astrojs/compiler": "^2.10.3",
-                "@astrojs/yaml2ts": "^0.2.1",
+                "@astrojs/yaml2ts": "^0.2.2",
                 "@jridgewell/sourcemap-codec": "^1.4.15",
-                "@volar/kit": "~2.4.5",
-                "@volar/language-core": "~2.4.5",
-                "@volar/language-server": "~2.4.5",
-                "@volar/language-service": "~2.4.5",
+                "@volar/kit": "~2.4.7",
+                "@volar/language-core": "~2.4.7",
+                "@volar/language-server": "~2.4.7",
+                "@volar/language-service": "~2.4.7",
                 "fast-glob": "^3.2.12",
                 "muggle-string": "^0.4.1",
-                "volar-service-css": "0.0.61",
-                "volar-service-emmet": "0.0.61",
-                "volar-service-html": "0.0.61",
-                "volar-service-prettier": "0.0.61",
-                "volar-service-typescript": "0.0.61",
-                "volar-service-typescript-twoslash-queries": "0.0.61",
-                "volar-service-yaml": "0.0.61",
+                "volar-service-css": "0.0.62",
+                "volar-service-emmet": "0.0.62",
+                "volar-service-html": "0.0.62",
+                "volar-service-prettier": "0.0.62",
+                "volar-service-typescript": "0.0.62",
+                "volar-service-typescript-twoslash-queries": "0.0.62",
+                "volar-service-yaml": "0.0.62",
                 "vscode-html-languageservice": "^5.2.0",
                 "vscode-uri": "^3.0.8"
             },
@@ -121,32 +135,19 @@
                 }
             }
         },
-        "node_modules/@astrojs/compiler": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
-            "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@astrojs/internal-helpers": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.1.tgz",
-            "integrity": "sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-5.3.0.tgz",
-            "integrity": "sha512-r0Ikqr0e6ozPb5bvhup1qdWnSPUvQu6tub4ZLYaKyG50BXZ0ej6FhGz3GpChKpH7kglRFPObJd/bDyf2VM9pkg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.0.0.tgz",
+            "integrity": "sha512-Tabo7xM44Pz2Yf9qpdaCCgxRmtaypi2YCinqTUNefDrWUa+OyKW62OuNeCaGwNh/ys+QAd9FUWN5/3HgPWjP4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@astrojs/prism": "3.1.0",
+                "@astrojs/prism": "3.2.0",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
                 "hast-util-to-text": "^4.0.2",
                 "import-meta-resolve": "^4.1.0",
+                "js-yaml": "^4.1.0",
                 "mdast-util-definitions": "^6.0.0",
                 "rehype-raw": "^7.0.0",
                 "rehype-stringify": "^10.0.1",
@@ -154,7 +155,7 @@
                 "remark-parse": "^11.0.0",
                 "remark-rehype": "^11.1.1",
                 "remark-smartypants": "^3.0.2",
-                "shiki": "^1.22.0",
+                "shiki": "^1.23.1",
                 "unified": "^11.0.5",
                 "unist-util-remove-position": "^5.0.0",
                 "unist-util-visit": "^5.0.0",
@@ -162,42 +163,62 @@
                 "vfile": "^6.0.3"
             }
         },
+        "node_modules/@astrojs/markdown-remark/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/@astrojs/markdown-remark/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/@astrojs/prism": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.1.0.tgz",
-            "integrity": "sha512-Z9IYjuXSArkAUx3N6xj6+Bnvx8OdUSHA8YoOgyepp3+zJmtVYJIl/I18GozdJVW1p5u/CNpl3Km7/gwTJK85cw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.2.0.tgz",
+            "integrity": "sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prismjs": "^1.29.0"
             },
             "engines": {
-                "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+                "node": "^18.17.1 || ^20.3.0 || >=22.0.0"
             }
         },
         "node_modules/@astrojs/telemetry": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.1.0.tgz",
-            "integrity": "sha512-/ca/+D8MIKEC8/A9cSaPUqQNZm+Es/ZinRv0ZAzvu2ios7POQSsVD+VOj7/hypWNsNM3T7RpfgNq7H2TU1KEHA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.0.tgz",
+            "integrity": "sha512-wxhSKRfKugLwLlr4OFfcqovk+LIFtKwLyGPqMsv+9/ibqqnW3Gv7tBhtKEb0gAyUAC4G9BTVQeQahqnQAhd6IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ci-info": "^4.0.0",
-                "debug": "^4.3.4",
+                "ci-info": "^4.1.0",
+                "debug": "^4.3.7",
                 "dlv": "^1.1.3",
-                "dset": "^3.1.3",
+                "dset": "^3.1.4",
                 "is-docker": "^3.0.0",
-                "is-wsl": "^3.0.0",
+                "is-wsl": "^3.1.0",
                 "which-pm-runs": "^1.1.0"
             },
             "engines": {
-                "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+                "node": "^18.17.1 || ^20.3.0 || >=22.0.0"
             }
         },
         "node_modules/@astrojs/telemetry/node_modules/ci-info": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-            "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
             "dev": true,
             "funding": [
                 {
@@ -211,9 +232,9 @@
             }
         },
         "node_modules/@astrojs/yaml2ts": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.1.tgz",
-            "integrity": "sha512-CBaNwDQJz20E5WxzQh4thLVfhB3JEEGz72wRA+oJp6fQR37QLAqXZJU0mHC+yqMOQ6oj0GfRPJrz6hjf+zm6zA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.2.tgz",
+            "integrity": "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -235,9 +256,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+            "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -275,6 +296,79 @@
                 "url": "https://opencollective.com/babel"
             }
         },
+        "node_modules/@babel/core/node_modules/@babel/generator": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.26.3",
+                "@babel/types": "^7.26.3",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/traverse": {
+            "version": "7.26.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+            "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.3",
+                "@babel/parser": "^7.26.3",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.3",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/core/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -286,30 +380,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "version": "7.17.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+            "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
-            "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.25.9"
+                "@babel/types": "^7.17.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -355,6 +434,20 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-environment-visitor/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-function-name": {
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
@@ -364,6 +457,20 @@
             "dependencies": {
                 "@babel/template": "^7.24.7",
                 "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -382,6 +489,20 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
@@ -394,6 +515,79 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/generator": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.26.3",
+                "@babel/types": "^7.26.3",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/traverse": {
+            "version": "7.26.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+            "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.3",
+                "@babel/parser": "^7.26.3",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.3",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
@@ -414,14 +608,77 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-            "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/generator": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.26.3",
+                "@babel/types": "^7.26.3",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
+            "version": "7.26.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+            "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.3",
+                "@babel/parser": "^7.26.3",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.3",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=6.9.0"
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
@@ -432,6 +689,20 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -480,14 +751,28 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/parser": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+        "node_modules/@babel/helpers/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+            "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.26.3"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -496,40 +781,18 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-            "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+        "node_modules/@babel/parser/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
-            "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.9",
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
-                "@babel/plugin-syntax-jsx": "^7.25.9",
-                "@babel/types": "^7.25.9"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/runtime": {
@@ -560,20 +823,68 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+        "node_modules/@babel/template/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/generator": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.25.9",
-                "debug": "^4.3.1",
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "debug": "^4.1.0",
                 "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/generator": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.26.3",
+                "@babel/types": "^7.26.3",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -589,15 +900,28 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@babel/traverse/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1425,13 +1749,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+            "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.4",
+                "@eslint/object-schema": "^2.1.5",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -1440,11 +1764,14 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
-            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+            "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -1507,9 +1834,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.15.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
-            "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+            "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1517,9 +1844,9 @@
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+            "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1527,9 +1854,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
-            "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+            "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2267,12 +2594,12 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
-            "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.5.0.tgz",
+            "integrity": "sha512-6TQAc/5uRILE6deixJ1CR8rXyTbzXIXNgO1D0Woi9Bqicz2FV5iKP3BHYEg6o4UATCMcbQQ0jbmeaOkn/HQk2w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "debug": "^4.3.6",
+                "debug": "^4.3.7",
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.4.0",
@@ -2311,23 +2638,17 @@
                 }
             }
         },
-        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
+            "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-            "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+            "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
             "cpu": [
                 "arm"
             ],
@@ -2339,9 +2660,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-            "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+            "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
             "cpu": [
                 "arm64"
             ],
@@ -2353,9 +2674,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-            "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+            "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2367,9 +2688,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-            "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+            "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
             "cpu": [
                 "x64"
             ],
@@ -2380,10 +2701,38 @@
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+            "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+            "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-            "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+            "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
             "cpu": [
                 "arm"
             ],
@@ -2395,9 +2744,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-            "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+            "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
             "cpu": [
                 "arm"
             ],
@@ -2409,9 +2758,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-            "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+            "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
             "cpu": [
                 "arm64"
             ],
@@ -2423,9 +2772,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-            "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+            "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
             "cpu": [
                 "arm64"
             ],
@@ -2436,10 +2785,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-            "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+            "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
             "cpu": [
                 "ppc64"
             ],
@@ -2451,9 +2814,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-            "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2465,9 +2828,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-            "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+            "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
             "cpu": [
                 "s390x"
             ],
@@ -2479,9 +2842,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-            "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+            "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
             "cpu": [
                 "x64"
             ],
@@ -2493,9 +2856,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-            "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+            "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
             "cpu": [
                 "x64"
             ],
@@ -2507,9 +2870,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-            "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+            "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
             "cpu": [
                 "arm64"
             ],
@@ -2521,9 +2884,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-            "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
             "cpu": [
                 "ia32"
             ],
@@ -2535,9 +2898,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-            "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
             "cpu": [
                 "x64"
             ],
@@ -2549,47 +2912,47 @@
             ]
         },
         "node_modules/@shikijs/core": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.2.tgz",
-            "integrity": "sha512-bvIQcd8BEeR1yFvOYv6HDiyta2FFVePbzeowf5pPS1avczrPK+cjmaxxh0nx5QzbON7+Sv0sQfQVciO7bN72sg==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.0.tgz",
+            "integrity": "sha512-6pvdH0KoahMzr6689yh0QJ3rCgF4j1XsXRHNEeEN6M4xJTfQ6QPWrmHzIddotg+xPJUPEPzYzYCKzpYyhTI6Gw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-javascript": "1.22.2",
-                "@shikijs/engine-oniguruma": "1.22.2",
-                "@shikijs/types": "1.22.2",
+                "@shikijs/engine-javascript": "1.24.0",
+                "@shikijs/engine-oniguruma": "1.24.0",
+                "@shikijs/types": "1.24.0",
                 "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.3"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.2.tgz",
-            "integrity": "sha512-iOvql09ql6m+3d1vtvP8fLCVCK7BQD1pJFmHIECsujB0V32BJ0Ab6hxk1ewVSMFA58FI0pR2Had9BKZdyQrxTw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.0.tgz",
+            "integrity": "sha512-ZA6sCeSsF3Mnlxxr+4wGEJ9Tto4RHmfIS7ox8KIAbH0MTVUkw3roHPHZN+LlJMOHJJOVupe6tvuAzRpN8qK1vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.2",
+                "@shikijs/types": "1.24.0",
                 "@shikijs/vscode-textmate": "^9.3.0",
-                "oniguruma-to-js": "0.4.3"
+                "oniguruma-to-es": "0.7.0"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.2.tgz",
-            "integrity": "sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.0.tgz",
+            "integrity": "sha512-Eua0qNOL73Y82lGA4GF5P+G2+VXX9XnuUxkiUuwcxQPH4wom+tE39kZpBFXfUuwNYxHSkrSxpB1p4kyRW0moSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.2",
+                "@shikijs/types": "1.24.0",
                 "@shikijs/vscode-textmate": "^9.3.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.2.tgz",
-            "integrity": "sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.0.tgz",
+            "integrity": "sha512-aptbEuq1Pk88DMlCe+FzXNnBZ17LCiLIGWAeCWhoFDzia5Q5Krx3DgnULLiouSdd6+LUM39XwXGppqYE0Ghtug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2636,179 +2999,6 @@
                 "@vue/compiler-sfc": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
-            "version": "7.17.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-            "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.17.0",
-                "jsesc": "^2.5.1",
-                "source-map": "^0.5.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
-            "version": "7.23.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.23.0",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.0",
-                "@babel/types": "^7.23.0",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
-            "version": "7.17.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.16.7",
-                "to-fast-properties": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@types/babel__core": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "node_modules/@types/babel__generator": {
-            "version": "7.6.8",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-            "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__traverse": {
-            "version": "7.20.6",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
-            "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.20.7"
             }
         },
         "node_modules/@types/cookie": {
@@ -2908,9 +3098,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.10.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.0.tgz",
-            "integrity": "sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==",
+            "version": "22.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+            "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2935,17 +3125,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.16.0.tgz",
-            "integrity": "sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz",
+            "integrity": "sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.16.0",
-                "@typescript-eslint/type-utils": "8.16.0",
-                "@typescript-eslint/utils": "8.16.0",
-                "@typescript-eslint/visitor-keys": "8.16.0",
+                "@typescript-eslint/scope-manager": "8.17.0",
+                "@typescript-eslint/type-utils": "8.17.0",
+                "@typescript-eslint/utils": "8.17.0",
+                "@typescript-eslint/visitor-keys": "8.17.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -2969,16 +3159,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
-            "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.17.0.tgz",
+            "integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.16.0",
-                "@typescript-eslint/types": "8.16.0",
-                "@typescript-eslint/typescript-estree": "8.16.0",
-                "@typescript-eslint/visitor-keys": "8.16.0",
+                "@typescript-eslint/scope-manager": "8.17.0",
+                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/typescript-estree": "8.17.0",
+                "@typescript-eslint/visitor-keys": "8.17.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2998,14 +3188,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
-            "integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
+            "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.16.0",
-                "@typescript-eslint/visitor-keys": "8.16.0"
+                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/visitor-keys": "8.17.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3016,14 +3206,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.16.0.tgz",
-            "integrity": "sha512-IqZHGG+g1XCWX9NyqnI/0CX5LL8/18awQqmkZSl2ynn8F76j579dByc0jhfVSnSnhf7zv76mKBQv9HQFKvDCgg==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz",
+            "integrity": "sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.16.0",
-                "@typescript-eslint/utils": "8.16.0",
+                "@typescript-eslint/typescript-estree": "8.17.0",
+                "@typescript-eslint/utils": "8.17.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -3044,9 +3234,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
-            "integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
+            "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3058,14 +3248,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
-            "integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
+            "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "8.16.0",
-                "@typescript-eslint/visitor-keys": "8.16.0",
+                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/visitor-keys": "8.17.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -3113,16 +3303,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
-            "integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
+            "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.16.0",
-                "@typescript-eslint/types": "8.16.0",
-                "@typescript-eslint/typescript-estree": "8.16.0"
+                "@typescript-eslint/scope-manager": "8.17.0",
+                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/typescript-estree": "8.17.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3141,13 +3331,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
-            "integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
+            "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.16.0",
+                "@typescript-eslint/types": "8.17.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -3166,9 +3356,9 @@
             "license": "ISC"
         },
         "node_modules/@vitest/coverage-istanbul": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.5.tgz",
-            "integrity": "sha512-jJsS5jeHncmSvzMNE03F1pk8F9etmjzGmGyQnGMkdHdVek/bxK/3vo8Qr3e9XmVuDM3UZKOy1ObeQHgC2OxvHg==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.8.tgz",
+            "integrity": "sha512-cSaCd8KcWWvgDwEJSXm0NEWZ1YTiJzjicKHy+zOEbUm0gjbbkz+qJf1p8q71uBzSlS7vdnZA8wRLeiwVE3fFTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3187,18 +3377,18 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "2.1.5"
+                "vitest": "2.1.8"
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.5.tgz",
-            "integrity": "sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+            "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "2.1.5",
-                "@vitest/utils": "2.1.5",
+                "@vitest/spy": "2.1.8",
+                "@vitest/utils": "2.1.8",
                 "chai": "^5.1.2",
                 "tinyrainbow": "^1.2.0"
             },
@@ -3206,47 +3396,10 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/mocker": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.5.tgz",
-            "integrity": "sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/spy": "2.1.5",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.12"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "msw": "^2.4.9",
-                "vite": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "msw": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@vitest/mocker/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
         "node_modules/@vitest/pretty-format": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.5.tgz",
-            "integrity": "sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+            "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3257,13 +3410,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.5.tgz",
-            "integrity": "sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+            "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "2.1.5",
+                "@vitest/utils": "2.1.8",
                 "pathe": "^1.1.2"
             },
             "funding": {
@@ -3271,13 +3424,13 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.5.tgz",
-            "integrity": "sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+            "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "2.1.5",
+                "@vitest/pretty-format": "2.1.8",
                 "magic-string": "^0.30.12",
                 "pathe": "^1.1.2"
             },
@@ -3286,9 +3439,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.5.tgz",
-            "integrity": "sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+            "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3299,13 +3452,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.5.tgz",
-            "integrity": "sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+            "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "2.1.5",
+                "@vitest/pretty-format": "2.1.8",
                 "loupe": "^3.1.2",
                 "tinyrainbow": "^1.2.0"
             },
@@ -3314,14 +3467,14 @@
             }
         },
         "node_modules/@volar/kit": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.6.tgz",
-            "integrity": "sha512-OaMtpmLns6IYD1nOSd0NdG/F5KzJ7Jr4B7TLeb4byPzu+ExuuRVeO56Dn1C7Frnw6bGudUQd90cpQAmxdB+RlQ==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.10.tgz",
+            "integrity": "sha512-ul+rLeO9RlFDgkY/FhPWMnpFqAsjvjkKz8VZeOY5YCJMwTblmmSBlNJtFNxSBx9t/k1q80nEthLyxiJ50ZbIAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-service": "2.4.6",
-                "@volar/typescript": "2.4.6",
+                "@volar/language-service": "2.4.10",
+                "@volar/typescript": "2.4.10",
                 "typesafe-path": "^0.2.2",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-uri": "^3.0.8"
@@ -3331,25 +3484,25 @@
             }
         },
         "node_modules/@volar/language-core": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.6.tgz",
-            "integrity": "sha512-FxUfxaB8sCqvY46YjyAAV6c3mMIq/NWQMVvJ+uS4yxr1KzOvyg61gAuOnNvgCvO4TZ7HcLExBEsWcDu4+K4E8A==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.10.tgz",
+            "integrity": "sha512-hG3Z13+nJmGaT+fnQzAkS0hjJRa2FCeqZt6Bd+oGNhUkQ+mTFsDETg5rqUTxyzIh5pSOGY7FHCWUS8G82AzLCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/source-map": "2.4.6"
+                "@volar/source-map": "2.4.10"
             }
         },
         "node_modules/@volar/language-server": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.6.tgz",
-            "integrity": "sha512-ARIbMXapEUPj9UFbZqWqw/iZ+ZuxUcY+vY212+2uutZVo/jrdzhLPu2TfZd9oB9akX8XXuslinT3051DyHLLRA==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.10.tgz",
+            "integrity": "sha512-odQsgrJh8hOXfxkSj/BSnpjThb2/KDhbxZnG/XAEx6E3QGDQv4hAOz9GWuKoNs0tkjgwphQGIwDMT1JYaTgRJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.6",
-                "@volar/language-service": "2.4.6",
-                "@volar/typescript": "2.4.6",
+                "@volar/language-core": "2.4.10",
+                "@volar/language-service": "2.4.10",
+                "@volar/typescript": "2.4.10",
                 "path-browserify": "^1.0.1",
                 "request-light": "^0.7.0",
                 "vscode-languageserver": "^9.0.1",
@@ -3359,41 +3512,41 @@
             }
         },
         "node_modules/@volar/language-service": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.6.tgz",
-            "integrity": "sha512-wNeEVBgBKgpP1MfMYPrgTf1K8nhOGEh3ac0+9n6ECyk2N03+j0pWCpQ2i99mRWT/POvo1PgizDmYFH8S67bZOA==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.10.tgz",
+            "integrity": "sha512-VxUiWS11rnRzakkqw5x1LPhsz+RBfD0CrrFarLGW2/voliYXEdCuSOM3r8JyNRvMvP4uwhD38ccAdTcULQEAIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.6",
+                "@volar/language-core": "2.4.10",
                 "vscode-languageserver-protocol": "^3.17.5",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-uri": "^3.0.8"
             }
         },
         "node_modules/@volar/source-map": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.6.tgz",
-            "integrity": "sha512-Nsh7UW2ruK+uURIPzjJgF0YRGP5CX9nQHypA2OMqdM2FKy7rh+uv3XgPnWPw30JADbKvZ5HuBzG4gSbVDYVtiw==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.10.tgz",
+            "integrity": "sha512-OCV+b5ihV0RF3A7vEvNyHPi4G4kFa6ukPmyVocmqm5QzOd8r5yAtiNvaPEjl8dNvgC/lj4JPryeeHLdXd62rWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.6.tgz",
-            "integrity": "sha512-NMIrA7y5OOqddL9VtngPWYmdQU03htNKFtAYidbYfWA0TOhyGVd9tfcP4TsLWQ+RBWDZCbBqsr8xzU0ZOxYTCQ==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.10.tgz",
+            "integrity": "sha512-F8ZtBMhSXyYKuBfGpYwqA5rsONnOwAVvjyE7KPYJ7wgZqo2roASqNWUnianOomJX5u1cxeRooHV59N0PhvEOgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.6",
+                "@volar/language-core": "2.4.10",
                 "path-browserify": "^1.0.1",
                 "vscode-uri": "^3.0.8"
             }
         },
         "node_modules/@vscode/emmet-helper": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.3.tgz",
-            "integrity": "sha512-rB39LHWWPQYYlYfpv9qCoZOVioPCftKXXqrsyqN1mTWZM6dTnONT63Db+03vgrBbHzJN45IrgS/AGxw9iiqfEw==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+            "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3401,15 +3554,8 @@
                 "jsonc-parser": "^2.3.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.15.1",
-                "vscode-uri": "^2.1.2"
+                "vscode-uri": "^3.0.8"
             }
-        },
-        "node_modules/@vscode/emmet-helper/node_modules/vscode-uri": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-            "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@vscode/l10n": {
             "version": "0.0.18",
@@ -3442,9 +3588,9 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.2.tgz",
+            "integrity": "sha512-JVzqkCNRT+VfqzzgPWDPnwvDheSAUdiMUn3NoLXpDJF5lRqeJqyC9iGsAxIOAW+mzIdq+uP1TvcX6bMtrH0agg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4"
@@ -3605,28 +3751,24 @@
             }
         },
         "node_modules/astro": {
-            "version": "4.16.14",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-4.16.14.tgz",
-            "integrity": "sha512-2IuLkIp4idyspugq+F52rHZyNqHHi2AdQzuKp3SGytg/YAm50dNeWhP/7l+enjgWZLloLq5xsH5gVQpoDFoyFg==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.0.3.tgz",
+            "integrity": "sha512-qpeN+POmmfAQu/XDXaI2CxkUgQFwH9uMUVaA1reV9rybzIbOVYc3E3BU5SkiP/W4BMUFPdJtyw6+/n/0AUv6rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@astrojs/compiler": "^2.10.3",
-                "@astrojs/internal-helpers": "0.4.1",
-                "@astrojs/markdown-remark": "5.3.0",
-                "@astrojs/telemetry": "3.1.0",
-                "@babel/core": "^7.26.0",
-                "@babel/plugin-transform-react-jsx": "^7.25.9",
-                "@babel/types": "^7.26.0",
+                "@astrojs/internal-helpers": "0.4.2",
+                "@astrojs/markdown-remark": "6.0.0",
+                "@astrojs/telemetry": "3.2.0",
                 "@oslojs/encoding": "^1.1.0",
                 "@rollup/pluginutils": "^5.1.3",
-                "@types/babel__core": "^7.20.5",
                 "@types/cookie": "^0.6.0",
                 "acorn": "^8.14.0",
                 "aria-query": "^5.3.2",
                 "axobject-query": "^4.1.0",
                 "boxen": "8.0.1",
-                "ci-info": "^4.0.0",
+                "ci-info": "^4.1.0",
                 "clsx": "^2.1.1",
                 "common-ancestor-path": "^1.0.1",
                 "cookie": "^0.7.2",
@@ -3643,33 +3785,33 @@
                 "fast-glob": "^3.3.2",
                 "flattie": "^1.1.1",
                 "github-slugger": "^2.0.0",
-                "gray-matter": "^4.0.3",
                 "html-escaper": "^3.0.3",
                 "http-cache-semantics": "^4.1.1",
                 "js-yaml": "^4.1.0",
                 "kleur": "^4.1.5",
-                "magic-string": "^0.30.12",
+                "magic-string": "^0.30.14",
                 "magicast": "^0.3.5",
                 "micromatch": "^4.0.8",
                 "mrmime": "^2.0.0",
                 "neotraverse": "^0.6.18",
-                "ora": "^8.1.1",
                 "p-limit": "^6.1.0",
                 "p-queue": "^8.0.1",
                 "preferred-pm": "^4.0.0",
                 "prompts": "^2.4.2",
                 "rehype": "^13.0.2",
                 "semver": "^7.6.3",
-                "shiki": "^1.22.2",
+                "shiki": "^1.23.1",
                 "tinyexec": "^0.3.1",
                 "tsconfck": "^3.1.4",
+                "ultrahtml": "^1.5.3",
                 "unist-util-visit": "^5.0.0",
                 "vfile": "^6.0.3",
-                "vite": "^5.4.10",
-                "vitefu": "^1.0.3",
+                "vite": "^6.0.1",
+                "vitefu": "^1.0.4",
                 "which-pm": "^3.0.0",
-                "xxhash-wasm": "^1.0.2",
+                "xxhash-wasm": "^1.1.0",
                 "yargs-parser": "^21.1.1",
+                "yocto-spinner": "^0.1.0",
                 "zod": "^3.23.8",
                 "zod-to-json-schema": "^3.23.5",
                 "zod-to-ts": "^1.2.0"
@@ -3678,7 +3820,7 @@
                 "astro": "astro.js"
             },
             "engines": {
-                "node": "^18.17.1 || ^20.3.0 || >=21.0.0",
+                "node": "^18.17.1 || ^20.3.0 || >=22.0.0",
                 "npm": ">=9.6.5",
                 "pnpm": ">=7.1.0"
             },
@@ -3698,9 +3840,9 @@
             "license": "Python-2.0"
         },
         "node_modules/astro/node_modules/ci-info": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-            "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
             "dev": true,
             "funding": [
                 {
@@ -3711,16 +3853,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/astro/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
             }
         },
         "node_modules/astro/node_modules/js-yaml": {
@@ -3823,13 +3955,12 @@
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz",
-            "integrity": "sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.4.2.tgz",
+            "integrity": "sha512-XZ4ln/KV4KT+PXdIWTKjsLY+quqCaEtqqtgGJVPw9AoM73By03ij64YjepK0aQvHSWDb6AfAZwqKaFu68qkrdA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "b4a": "^1.6.6",
                 "streamx": "^2.20.0"
             }
         },
@@ -4051,9 +4182,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001677",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-            "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+            "version": "1.0.30001687",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
+            "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
             "dev": true,
             "funding": [
                 {
@@ -4260,35 +4391,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-cursor": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "restore-cursor": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4596,9 +4698,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -4723,9 +4825,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1342118",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz",
-            "integrity": "sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==",
+            "version": "0.0.1367902",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+            "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
@@ -4845,9 +4947,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.50",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
-            "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
+            "version": "1.5.71",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz",
+            "integrity": "sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4872,6 +4974,13 @@
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
             "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex-xs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+            "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
             "dev": true,
             "license": "MIT"
         },
@@ -5046,10 +5155,20 @@
                 "source-map": "~0.6.1"
             }
         },
+        "node_modules/escodegen/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/eslint": {
-            "version": "9.15.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
-            "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
+            "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5058,7 +5177,7 @@
                 "@eslint/config-array": "^0.19.0",
                 "@eslint/core": "^0.9.0",
                 "@eslint/eslintrc": "^3.2.0",
-                "@eslint/js": "9.15.0",
+                "@eslint/js": "9.16.0",
                 "@eslint/plugin-kit": "^0.2.3",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -5417,11 +5536,14 @@
             }
         },
         "node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -5455,19 +5577,6 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/extendable-error": {
             "version": "0.1.7",
@@ -5582,11 +5691,11 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-            "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
             "dev": true,
-            "license": "MIT"
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.17.1",
@@ -5605,6 +5714,21 @@
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/file-entry-cache": {
@@ -5686,9 +5810,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
             "dev": true,
             "license": "ISC"
         },
@@ -5769,9 +5893,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5810,53 +5934,17 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+            "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
             "license": "MIT",
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/get-uri/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/get-uri/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/get-uri/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/github-slugger": {
@@ -5930,9 +6018,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "15.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
-            "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
+            "version": "15.13.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-15.13.0.tgz",
+            "integrity": "sha512-49TewVEz0UxZjr1WYYsWpPrhyC/B/pA8Bq0fUmet2n+eR7yn0IvNzNaoBwnK6mdkzcN+se7Ez9zUgULTz2QH4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5967,6 +6055,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/graphemer": {
@@ -5975,22 +6064,6 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/gray-matter": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-            "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "js-yaml": "^3.13.1",
-                "kind-of": "^6.0.2",
-                "section-matter": "^1.0.0",
-                "strip-bom-string": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -6022,16 +6095,16 @@
             }
         },
         "node_modules/hast-util-from-parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
-            "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.2.tgz",
+            "integrity": "sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
                 "devlop": "^1.0.0",
-                "hastscript": "^8.0.0",
+                "hastscript": "^9.0.0",
                 "property-information": "^6.0.0",
                 "vfile": "^6.0.0",
                 "vfile-location": "^5.0.0",
@@ -6071,9 +6144,9 @@
             }
         },
         "node_modules/hast-util-raw": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.4.tgz",
-            "integrity": "sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6172,9 +6245,9 @@
             }
         },
         "node_modules/hastscript": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
-            "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+            "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6248,12 +6321,12 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -6397,16 +6470,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6458,19 +6521,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-interactive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6505,19 +6555,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/is-unicode-supported": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-windows": {
@@ -6691,16 +6728,16 @@
             "license": "MIT"
         },
         "node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=4"
             }
         },
         "node_modules/json-buffer": {
@@ -6770,16 +6807,6 @@
                 "json-buffer": "3.0.1"
             }
         },
-        "node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/kleur": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -6804,9 +6831,9 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6889,36 +6916,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/log-symbols": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^5.3.0",
-                "is-unicode-supported": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/longest-streak": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -6948,9 +6945,9 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.12",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-            "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+            "version": "0.30.14",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
+            "integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6967,6 +6964,20 @@
                 "@babel/parser": "^7.25.4",
                 "@babel/types": "^7.25.4",
                 "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/magicast/node_modules/@babel/types": {
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/make-dir": {
@@ -6986,9 +6997,9 @@
             }
         },
         "node_modules/markdown-table": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -7043,9 +7054,9 @@
             }
         },
         "node_modules/mdast-util-from-markdown": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.1.tgz",
-            "integrity": "sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+            "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7212,9 +7223,9 @@
             }
         },
         "node_modules/mdast-util-to-markdown": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
-            "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7223,6 +7234,7 @@
                 "longest-streak": "^3.0.0",
                 "mdast-util-phrasing": "^4.0.0",
                 "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
                 "micromark-util-decode-string": "^2.0.0",
                 "unist-util-visit": "^5.0.0",
                 "zwitch": "^2.0.0"
@@ -7257,9 +7269,9 @@
             }
         },
         "node_modules/micromark": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-            "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
+            "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
             "dev": true,
             "funding": [
                 {
@@ -7293,9 +7305,9 @@
             }
         },
         "node_modules/micromark-core-commonmark": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.1.tgz",
-            "integrity": "sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
+            "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
             "dev": true,
             "funding": [
                 {
@@ -7456,9 +7468,9 @@
             }
         },
         "node_modules/micromark-factory-destination": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
-            "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
             "dev": true,
             "funding": [
                 {
@@ -7478,9 +7490,9 @@
             }
         },
         "node_modules/micromark-factory-label": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
-            "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
             "dev": true,
             "funding": [
                 {
@@ -7501,9 +7513,9 @@
             }
         },
         "node_modules/micromark-factory-space": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "dev": true,
             "funding": [
                 {
@@ -7522,9 +7534,9 @@
             }
         },
         "node_modules/micromark-factory-title": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
-            "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
             "dev": true,
             "funding": [
                 {
@@ -7545,9 +7557,9 @@
             }
         },
         "node_modules/micromark-factory-whitespace": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
-            "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
             "dev": true,
             "funding": [
                 {
@@ -7568,9 +7580,9 @@
             }
         },
         "node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "dev": true,
             "funding": [
                 {
@@ -7589,9 +7601,9 @@
             }
         },
         "node_modules/micromark-util-chunked": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
-            "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
             "dev": true,
             "funding": [
                 {
@@ -7609,9 +7621,9 @@
             }
         },
         "node_modules/micromark-util-classify-character": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
-            "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
             "dev": true,
             "funding": [
                 {
@@ -7631,9 +7643,9 @@
             }
         },
         "node_modules/micromark-util-combine-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
-            "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
             "dev": true,
             "funding": [
                 {
@@ -7652,9 +7664,9 @@
             }
         },
         "node_modules/micromark-util-decode-numeric-character-reference": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
-            "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
             "dev": true,
             "funding": [
                 {
@@ -7672,9 +7684,9 @@
             }
         },
         "node_modules/micromark-util-decode-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
-            "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
             "dev": true,
             "funding": [
                 {
@@ -7695,9 +7707,9 @@
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
             "dev": true,
             "funding": [
                 {
@@ -7712,9 +7724,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-html-tag-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
-            "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
             "dev": true,
             "funding": [
                 {
@@ -7729,9 +7741,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-normalize-identifier": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
-            "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
             "dev": true,
             "funding": [
                 {
@@ -7749,9 +7761,9 @@
             }
         },
         "node_modules/micromark-util-resolve-all": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
-            "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
             "dev": true,
             "funding": [
                 {
@@ -7769,9 +7781,9 @@
             }
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
             "dev": true,
             "funding": [
                 {
@@ -7791,9 +7803,9 @@
             }
         },
         "node_modules/micromark-util-subtokenize": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.1.tgz",
-            "integrity": "sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.3.tgz",
+            "integrity": "sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==",
             "dev": true,
             "funding": [
                 {
@@ -7814,9 +7826,9 @@
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "dev": true,
             "funding": [
                 {
@@ -7831,9 +7843,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+            "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
             "dev": true,
             "funding": [
                 {
@@ -7861,17 +7873,17 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=8.6"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/minimatch": {
@@ -7949,9 +7961,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
                 {
@@ -8067,33 +8079,16 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+        "node_modules/oniguruma-to-es": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.7.0.tgz",
+            "integrity": "sha512-HRaRh09cE0gRS3+wi2zxekB+I5L8C/gN60S+vb11eADHUaB/q4u8wGGOX3GvwvitG8ixaeycZfeoyruKQzUgNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mimic-function": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regex": "^4.3.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
+                "emoji-regex-xs": "^1.0.0",
+                "regex": "^5.0.2",
+                "regex-recursion": "^4.3.0"
             }
         },
         "node_modules/optionator": {
@@ -8112,59 +8107,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/ora": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.1.tgz",
-            "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^5.3.0",
-                "cli-cursor": "^5.0.0",
-                "cli-spinners": "^2.9.2",
-                "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^2.0.0",
-                "log-symbols": "^6.0.0",
-                "stdin-discarder": "^0.2.2",
-                "string-width": "^7.2.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/os-tmpdir": {
@@ -8254,9 +8196,9 @@
             }
         },
         "node_modules/p-timeout": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-            "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
+            "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8277,19 +8219,19 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
+            "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
             "license": "MIT",
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.5",
+                "https-proxy-agent": "^7.0.6",
                 "pac-resolver": "^7.0.1",
-                "socks-proxy-agent": "^8.0.4"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -8316,9 +8258,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/package-manager-detector": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.2.tgz",
-            "integrity": "sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.7.tgz",
+            "integrity": "sha512-g4+387DXDKlZzHkP+9FLt8yKj8+/3tOkPv7DVTJGGRm00RkEWgqbFstX1mXJ4M0VDYhUqsTOiISqNOJnhAu3PQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -8372,9 +8314,9 @@
             }
         },
         "node_modules/parse5": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
-            "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+            "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8534,13 +8476,13 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -8580,9 +8522,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.47",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+            "version": "8.4.49",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
             "dev": true,
             "funding": [
                 {
@@ -8601,7 +8543,7 @@
             "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.1.0",
+                "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
             "engines": {
@@ -8677,9 +8619,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.0.tgz",
-            "integrity": "sha512-/OXNZcLyWkfo13ofOW5M7SLh+k5pnIs07owXK2teFpnfaOEcycnSy7HQxldaVX1ZP/7Q8oO1eDuQJNwbomQq5Q==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8747,19 +8689,19 @@
             }
         },
         "node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
+                "pac-proxy-agent": "^7.1.0",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -8801,17 +8743,17 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "23.5.3",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.5.3.tgz",
-            "integrity": "sha512-FghmfBsr/UUpe48OiCg1gV3W4vVfQJKjQehbF07SjnQvEpWcvPTah1nykfGWdOQQ1ydJPIXcajzWN7fliCU3zw==",
+            "version": "23.10.1",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.10.1.tgz",
+            "integrity": "sha512-kbcO+vu91fgUyBzEwByPe4q5lEEuBq4cuOZnZeRL42G7r5UrfbUFlxBJayXBLBsD6pREdk/92ZFwFQq3MaN6ww==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.4.0",
+                "@puppeteer/browsers": "2.5.0",
                 "chromium-bidi": "0.8.0",
                 "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1342118",
-                "puppeteer-core": "23.5.3",
+                "devtools-protocol": "0.0.1367902",
+                "puppeteer-core": "23.10.1",
                 "typed-query-selector": "^2.12.0"
             },
             "bin": {
@@ -8822,15 +8764,15 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "23.5.3",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.5.3.tgz",
-            "integrity": "sha512-V58MZD/B3CwkYsqSEQlHKbavMJptF04fzhMdUpiCRCmUVhwZNwSGEPhaiZ1f8I3ABQUirg3VNhXVB6Z1ubHXtQ==",
+            "version": "23.10.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.10.1.tgz",
+            "integrity": "sha512-ey6NwixHYEUnhCA/uYi7uQQ4a0CZw4k+MatbHXGl5GEzaiRQziYUxc2HGpdQZ/gnh4KQWAKkocyIg1/dIm5d0g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.4.0",
+                "@puppeteer/browsers": "2.5.0",
                 "chromium-bidi": "0.8.0",
                 "debug": "^4.3.7",
-                "devtools-protocol": "0.0.1342118",
+                "devtools-protocol": "0.0.1367902",
                 "typed-query-selector": "^2.12.0",
                 "ws": "^8.18.0"
             },
@@ -8903,9 +8845,29 @@
             "license": "MIT"
         },
         "node_modules/regex": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.4.0.tgz",
-            "integrity": "sha512-uCUSuobNVeqUupowbdZub6ggI5/JZkYyJdDogddJr60L764oxC2pMZov1fQ3wM9bdyzUILDG+Sqx6NAKAz9rKQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
+            "integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-recursion": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-4.3.0.tgz",
+            "integrity": "sha512-5LcLnizwjcQ2ALfOj95MjcatxyqF5RPySx9yT+PaXu3Gox2vyAtLDjHB8NTJLtMGkvyau6nI3CfpwFCjPUIs/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "dev": true,
             "license": "MIT"
         },
@@ -9106,23 +9068,6 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/restore-cursor": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "onetime": "^7.0.0",
-                "signal-exit": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/retext": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -9200,9 +9145,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-            "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+            "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9216,22 +9161,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.24.0",
-                "@rollup/rollup-android-arm64": "4.24.0",
-                "@rollup/rollup-darwin-arm64": "4.24.0",
-                "@rollup/rollup-darwin-x64": "4.24.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-                "@rollup/rollup-linux-arm64-musl": "4.24.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-musl": "4.24.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-                "@rollup/rollup-win32-x64-msvc": "4.24.0",
+                "@rollup/rollup-android-arm-eabi": "4.28.1",
+                "@rollup/rollup-android-arm64": "4.28.1",
+                "@rollup/rollup-darwin-arm64": "4.28.1",
+                "@rollup/rollup-darwin-x64": "4.28.1",
+                "@rollup/rollup-freebsd-arm64": "4.28.1",
+                "@rollup/rollup-freebsd-x64": "4.28.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+                "@rollup/rollup-linux-arm64-musl": "4.28.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-musl": "4.28.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+                "@rollup/rollup-win32-x64-msvc": "4.28.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -9265,20 +9213,6 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/section-matter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-            "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "extend-shallow": "^2.0.1",
-                "kind-of": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/semver": {
             "version": "7.6.3",
@@ -9357,16 +9291,16 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.2.tgz",
-            "integrity": "sha512-3IZau0NdGKXhH2bBlUk4w1IHNxPh6A5B2sUpyY+8utLu2j/h1QpFkAaUA1bAMxOWWGtTWcAh531vnS4NJKS/lA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.0.tgz",
+            "integrity": "sha512-qIneep7QRwxRd5oiHb8jaRzH15V/S8F3saCXOdjwRLgozZJr5x2yeBhQtqkO3FSzQDwYEFAYuifg4oHjpDghrg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "1.22.2",
-                "@shikijs/engine-javascript": "1.22.2",
-                "@shikijs/engine-oniguruma": "1.22.2",
-                "@shikijs/types": "1.22.2",
+                "@shikijs/core": "1.24.0",
+                "@shikijs/engine-javascript": "1.24.0",
+                "@shikijs/engine-oniguruma": "1.24.0",
+                "@shikijs/types": "1.24.0",
                 "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
@@ -9452,12 +9386,12 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.1.1",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "socks": "^2.8.3"
             },
@@ -9466,11 +9400,11 @@
             }
         },
         "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
             "license": "BSD-3-Clause",
-            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9528,23 +9462,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/stdin-discarder": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/streamx": {
-            "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
-            "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
+            "version": "2.21.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.0.tgz",
+            "integrity": "sha512-Qz6MsDZXJ6ur9u+b+4xCG18TluU7PGlRfXVAAjNiGsFrBUt/ioyLkxbFaKJygoPs+/kW4VyBj0bSj89Qu0IGyg==",
             "license": "MIT",
             "dependencies": {
                 "fast-fifo": "^1.3.2",
@@ -9674,16 +9595,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/strip-bom-string": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/strip-json-comments": {
@@ -9973,9 +9884,9 @@
             }
         },
         "node_modules/text-decoder": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz",
-            "integrity": "sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.2.tgz",
+            "integrity": "sha512-/MDslo7ZyWTA2vnk1j7XoDVfXsGk3tp+zFEJHJGm0UjIlQifonVFwlVbQDFh8KJzTBnT8ie115TYqir6bclddA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
@@ -10036,34 +9947,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/tinypool": {
@@ -10172,9 +10055,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.2.tgz",
-            "integrity": "sha512-ZF5gQIQa/UmzfvxbHZI3JXN0/Jt+vnAfAviNRAMc491laiK6YCLpCW9ft8oaCRFOTxCZtUTE6XB0ZQAe3olntw==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10213,9 +10096,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
         "node_modules/tsup": {
@@ -10757,9 +10640,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-            "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
+            "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -10783,9 +10666,9 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -10797,9 +10680,9 @@
             }
         },
         "node_modules/typescript-auto-import-cache": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.3.tgz",
-            "integrity": "sha512-ojEC7+Ci1ij9eE6hp8Jl9VUNnsEKzztktP5gtYNRMrTmfXVwA1PITYYAkpxCvvupdSYa/Re51B6KMcv1CTZEUA==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.5.tgz",
+            "integrity": "sha512-fAIveQKsoYj55CozUiBoj4b/7WpN0i4o74wiGY5JVUEoD0XiqDk1tJqTEjgzL2/AizKQrXxyRosSebyDzBZKjw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10807,15 +10690,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.16.0.tgz",
-            "integrity": "sha512-wDkVmlY6O2do4V+lZd0GtRfbtXbeD0q9WygwXXSJnC1xorE8eqyC2L1tJimqpSeFrOzRlYtWnUp/uzgHQOgfBQ==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.17.0.tgz",
+            "integrity": "sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.16.0",
-                "@typescript-eslint/parser": "8.16.0",
-                "@typescript-eslint/utils": "8.16.0"
+                "@typescript-eslint/eslint-plugin": "8.17.0",
+                "@typescript-eslint/parser": "8.17.0",
+                "@typescript-eslint/utils": "8.17.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10833,6 +10716,13 @@
                 }
             }
         },
+        "node_modules/ultrahtml": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.5.3.tgz",
+            "integrity": "sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/unbzip2-stream": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -10844,9 +10734,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.0.tgz",
-            "integrity": "sha512-AITZfPuxubm31Sx0vr8bteSalEbs9wQb/BOBi9FPlD9Qpd6HxZ4Q0+hI742jBhkPb4RT2v5MQzaW5VhRVyj+9A==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+            "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11115,9 +11005,104 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.10",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
-            "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.3.tgz",
+            "integrity": "sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.24.0",
+                "postcss": "^8.4.49",
+                "rollup": "^4.23.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "jiti": ">=1.21.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+            "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.7",
+                "es-module-lexer": "^1.5.4",
+                "pathe": "^1.1.2",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-node/node_modules/vite": {
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11174,33 +11159,441 @@
                 }
             }
         },
-        "node_modules/vite-node": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.5.tgz",
-            "integrity": "sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==",
+        "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
+            "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+            "cpu": [
+                "ppc64"
+            ],
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.3.7",
-                "es-module-lexer": "^1.5.4",
-                "pathe": "^1.1.2",
-                "vite": "^5.0.0"
-            },
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
+            "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
+            "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
+            "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+            "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
+            "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
+            "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
+            "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
+            "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
+            "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
+            "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
+            "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
+            "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
+            "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
+            "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
+            "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
+            "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
+            "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
+            "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
+            "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
+            "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
+            "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-x64": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
+            "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/esbuild": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
+            "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
             "bin": {
-                "vite-node": "vite-node.mjs"
+                "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": ">=18"
             },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.24.0",
+                "@esbuild/android-arm": "0.24.0",
+                "@esbuild/android-arm64": "0.24.0",
+                "@esbuild/android-x64": "0.24.0",
+                "@esbuild/darwin-arm64": "0.24.0",
+                "@esbuild/darwin-x64": "0.24.0",
+                "@esbuild/freebsd-arm64": "0.24.0",
+                "@esbuild/freebsd-x64": "0.24.0",
+                "@esbuild/linux-arm": "0.24.0",
+                "@esbuild/linux-arm64": "0.24.0",
+                "@esbuild/linux-ia32": "0.24.0",
+                "@esbuild/linux-loong64": "0.24.0",
+                "@esbuild/linux-mips64el": "0.24.0",
+                "@esbuild/linux-ppc64": "0.24.0",
+                "@esbuild/linux-riscv64": "0.24.0",
+                "@esbuild/linux-s390x": "0.24.0",
+                "@esbuild/linux-x64": "0.24.0",
+                "@esbuild/netbsd-x64": "0.24.0",
+                "@esbuild/openbsd-arm64": "0.24.0",
+                "@esbuild/openbsd-x64": "0.24.0",
+                "@esbuild/sunos-x64": "0.24.0",
+                "@esbuild/win32-arm64": "0.24.0",
+                "@esbuild/win32-ia32": "0.24.0",
+                "@esbuild/win32-x64": "0.24.0"
             }
         },
         "node_modules/vitefu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.3.tgz",
-            "integrity": "sha512-iKKfOMBHob2WxEJbqbJjHAkmYgvFDPhuqrO82om83S8RLk+17FtyMBfcyeH8GqD0ihShtkMW/zzJgiA51hCNCQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.4.tgz",
+            "integrity": "sha512-y6zEE3PQf6uu/Mt6DTJ9ih+kyJLr4XcSgHR2zUkM8SWDhuixEJxfJ6CZGMHh1Ec3vPLoEA0IHU5oWzVqw8ulow==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -11208,7 +11601,7 @@
                 "tests/projects/*"
             ],
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0"
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
             },
             "peerDependenciesMeta": {
                 "vite": {
@@ -11217,19 +11610,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.5.tgz",
-            "integrity": "sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+            "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "2.1.5",
-                "@vitest/mocker": "2.1.5",
-                "@vitest/pretty-format": "^2.1.5",
-                "@vitest/runner": "2.1.5",
-                "@vitest/snapshot": "2.1.5",
-                "@vitest/spy": "2.1.5",
-                "@vitest/utils": "2.1.5",
+                "@vitest/expect": "2.1.8",
+                "@vitest/mocker": "2.1.8",
+                "@vitest/pretty-format": "^2.1.8",
+                "@vitest/runner": "2.1.8",
+                "@vitest/snapshot": "2.1.8",
+                "@vitest/spy": "2.1.8",
+                "@vitest/utils": "2.1.8",
                 "chai": "^5.1.2",
                 "debug": "^4.3.7",
                 "expect-type": "^1.1.0",
@@ -11241,7 +11634,7 @@
                 "tinypool": "^1.0.1",
                 "tinyrainbow": "^1.2.0",
                 "vite": "^5.0.0",
-                "vite-node": "2.1.5",
+                "vite-node": "2.1.8",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -11256,8 +11649,8 @@
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
                 "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "2.1.5",
-                "@vitest/ui": "2.1.5",
+                "@vitest/browser": "2.1.8",
+                "@vitest/ui": "2.1.8",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
@@ -11282,10 +11675,97 @@
                 }
             }
         },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+            "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.8",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/volar-service-css": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.61.tgz",
-            "integrity": "sha512-Ct9L/w+IB1JU8F4jofcNCGoHy6TF83aiapfZq9A0qYYpq+Kk5dH+ONS+rVZSsuhsunq8UvAuF8Gk6B8IFLfniw==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.62.tgz",
+            "integrity": "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11303,9 +11783,9 @@
             }
         },
         "node_modules/volar-service-emmet": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.61.tgz",
-            "integrity": "sha512-iiYqBxjjcekqrRruw4COQHZME6EZYWVbkHjHDbULpml3g8HGJHzpAMkj9tXNCPxf36A+f1oUYjsvZt36qPg4cg==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.62.tgz",
+            "integrity": "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11324,9 +11804,9 @@
             }
         },
         "node_modules/volar-service-html": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.61.tgz",
-            "integrity": "sha512-yFE+YmmgqIL5HI4ORqP++IYb1QaGcv+xBboI0WkCxJJ/M35HZj7f5rbT3eQ24ECLXFbFCFanckwyWJVz5KmN3Q==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.62.tgz",
+            "integrity": "sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11344,9 +11824,9 @@
             }
         },
         "node_modules/volar-service-prettier": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.61.tgz",
-            "integrity": "sha512-F612nql5I0IS8HxXemCGvOR2Uxd4XooIwqYVUvk7WSBxP/+xu1jYvE3QJ7EVpl8Ty3S4SxPXYiYTsG3bi+gzIQ==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.62.tgz",
+            "integrity": "sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11366,9 +11846,9 @@
             }
         },
         "node_modules/volar-service-typescript": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.61.tgz",
-            "integrity": "sha512-4kRHxVbW7wFBHZWRU6yWxTgiKETBDIJNwmJUAWeP0mHaKpnDGj/astdRFKqGFRYVeEYl45lcUPhdJyrzanjsdQ==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.62.tgz",
+            "integrity": "sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11389,9 +11869,9 @@
             }
         },
         "node_modules/volar-service-typescript-twoslash-queries": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.61.tgz",
-            "integrity": "sha512-99FICGrEF0r1E2tV+SvprHPw9Knyg7BdW2fUch0tf59kG+KG+Tj4tL6tUg+cy8f23O/VXlmsWFMIE+bx1dXPnQ==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.62.tgz",
+            "integrity": "sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11407,9 +11887,9 @@
             }
         },
         "node_modules/volar-service-yaml": {
-            "version": "0.0.61",
-            "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.61.tgz",
-            "integrity": "sha512-L+gbDiLDQQ1rZUbJ3mf3doDsoQUa8OZM/xdpk/unMg1Vz24Zmi2Ign8GrZyBD7bRoIQDwOH9gdktGDKzRPpUNw==",
+            "version": "0.0.62",
+            "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.62.tgz",
+            "integrity": "sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11426,9 +11906,9 @@
             }
         },
         "node_modules/vscode-css-languageservice": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.1.tgz",
-            "integrity": "sha512-1BzTBuJfwMc3A0uX4JBdJgoxp74cjj4q2mDJdp49yD/GuAq4X0k5WtK6fNcMYr+FfJ9nqgR6lpfCSZDkARJ5qQ==",
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.2.tgz",
+            "integrity": "sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11803,9 +12283,9 @@
             }
         },
         "node_modules/xxhash-wasm": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
-            "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+            "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
             "dev": true,
             "license": "MIT"
         },
@@ -11826,9 +12306,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -12032,6 +12512,35 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yocto-spinner": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.1.1.tgz",
+            "integrity": "sha512-vb6yztJdmbX9BwiR2NlKim7roGM5xFFhiTO6UstNiKBnh8NT6uFNjpXYC6DWTnLgRRyHh2nDNEM8kLHSRLw4kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=18.19"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+            "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/zod": {
             "version": "3.23.8",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
@@ -12076,37 +12585,9 @@
             "name": "@test/build-pdf",
             "devDependencies": {
                 "@astrojs/check": "^0.9.4",
-                "astro": "^4.15.12",
+                "astro": "^5.0.3",
                 "astro-pdf": "^1.2.0",
                 "typescript": "^5.6.2"
-            }
-        },
-        "test/fixtures/netlify-adapter": {
-            "name": "@test/vercel-adapter",
-            "extraneous": true,
-            "devDependencies": {
-                "@astrojs/netlify": "^5.5.4",
-                "@astrojs/node": "^8.3.4",
-                "astro": "^4.16.8",
-                "astro-pdf": "^1.0.0",
-                "netlify-cli": "^17.37.2"
-            }
-        },
-        "test/fixtures/node-adapter": {
-            "name": "@test/vercel-adapter",
-            "extraneous": true,
-            "devDependencies": {
-                "astro": "^4.16.8",
-                "astro-pdf": "^1.0.0"
-            }
-        },
-        "test/fixtures/vercel-adapter": {
-            "name": "@test/vercel-adapter",
-            "extraneous": true,
-            "devDependencies": {
-                "@astrojs/node": "^8.3.4",
-                "astro": "^4.16.8",
-                "astro-pdf": "^1.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -33,34 +33,34 @@
         "pdf-generation"
     ],
     "dependencies": {
-        "@puppeteer/browsers": "^2.4.0",
+        "@puppeteer/browsers": "^2.5.0",
         "kleur": "^4.1.5",
-        "puppeteer": "^23.5.3"
+        "puppeteer": "^23.10.1"
     },
     "peerDependencies": {
-        "astro": "^4.4.4"
+        "astro": "^4.4.4 || ^5.0.0"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.10",
-        "@eslint/js": "^9.15.0",
+        "@eslint/js": "^9.16.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
-        "@types/node": "^22.10.0",
-        "@vitest/coverage-istanbul": "^2.1.5",
-        "astro": "^4.16.14",
+        "@types/node": "^22.10.1",
+        "@vitest/coverage-istanbul": "^2.1.8",
+        "astro": "^5.0.3",
         "cheerio": "^1.0.0",
-        "eslint": "^9.15.0",
+        "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-n": "^17.14.0",
         "glob": "^11.0.0",
-        "globals": "^15.12.0",
+        "globals": "^15.13.0",
         "pdf2json": "^3.1.4",
-        "prettier": "^3.4.0",
+        "prettier": "^3.4.2",
         "tsup": "^8.3.5",
-        "typescript-eslint": "^8.16.0",
-        "vitest": "^2.1.5"
+        "typescript-eslint": "^8.17.0",
+        "vitest": "^2.1.8"
     },
     "workspaces": [
         "./",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,3 +1,5 @@
+import { lstat } from 'node:fs/promises'
+
 import { Browser, detectBrowserPlatform, install, resolveBuildId, type InstallOptions } from '@puppeteer/browsers'
 import { type AstroIntegrationLogger } from 'astro'
 import { dim, yellow } from 'kleur/colors'
@@ -26,7 +28,11 @@ export async function findOrInstallBrowser(
     if (!options) {
         try {
             defaultPath = executablePath()
+            // puppeteer ^23.10.0 no longer checks if the path exists
+            // using lstat which will also throw if it does not exist
+            await lstat(defaultPath)
         } catch (e) {
+            defaultPath = null
             logger.debug('error: ' + e)
             logger.info(yellow(`could not find default browser. installing browser...`))
         }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,12 +1,12 @@
 import type { InstallOptions } from '@puppeteer/browsers'
 import type { AstroConfig } from 'astro'
-import type { Page, PDFOptions, PuppeteerLaunchOptions, PuppeteerLifeCycleEvent } from 'puppeteer'
+import type { Page, PDFOptions, LaunchOptions, PuppeteerLifeCycleEvent } from 'puppeteer'
 
 import type { ServerOutput } from './server.js'
 
 export interface Options {
     install?: boolean | Partial<InstallOptions>
-    launch?: PuppeteerLaunchOptions
+    launch?: LaunchOptions
     baseOptions?: Partial<PageOptions>
     server?: ((config: AstroConfig) => ServerOutput | Promise<ServerOutput>) | false
     pages: PagesFunction | PagesMap

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -97,6 +97,7 @@ describe('custom server', () => {
                 injectTypes: () => {
                     throw new Error('unimplemented')
                 },
+                buildOutput: 'static',
                 logger
             })
             await integration.hooks['astro:build:done']!({
@@ -104,7 +105,7 @@ describe('custom server', () => {
                 dir: new URL('dist', root),
                 routes: [],
                 logger,
-                cacheManifest: false
+                assets: new Map()
             })
         })
 
@@ -144,6 +145,7 @@ describe('custom server', () => {
                 injectTypes: () => {
                     throw new Error('unimplemented')
                 },
+                buildOutput: 'static',
                 logger
             })
             await integration.hooks['astro:build:done']!({
@@ -151,7 +153,7 @@ describe('custom server', () => {
                 dir: new URL('dist', root),
                 routes: [],
                 logger,
-                cacheManifest: false
+                assets: new Map()
             })
         })
 
@@ -193,6 +195,7 @@ describe('custom server', () => {
                 injectTypes: () => {
                     throw new Error('unimplemented')
                 },
+                buildOutput: 'static',
                 logger
             })
             await integration.hooks['astro:build:done']!({
@@ -200,7 +203,7 @@ describe('custom server', () => {
                 dir: new URL('dist', root),
                 routes: [],
                 logger,
-                cacheManifest: false
+                assets: new Map()
             })
         })
 

--- a/test/fixtures/build-pdf/package.json
+++ b/test/fixtures/build-pdf/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "@astrojs/check": "^0.9.4",
-        "astro": "^4.15.12",
+        "astro": "^5.0.3",
         "astro-pdf": "^1.2.0",
         "typescript": "^5.6.2"
     }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -71,6 +71,7 @@ describe('run integration', () => {
                 injectTypes: () => {
                     throw new Error('unimplemented')
                 },
+                buildOutput: 'static',
                 logger
             })
         })
@@ -81,7 +82,7 @@ describe('run integration', () => {
                 dir: outDir,
                 routes: [],
                 logger,
-                cacheManifest: false
+                assets: new Map()
             })
         }, 20000)
 


### PR DESCRIPTION
Added support for [Astro v5.0](https://docs.astro.build/en/guides/upgrade-to/v5/).
- Updated peer dependency to allow both Astro 4 and Astro 5
- Updated tests to Astro 5

Updated puppeteer to latest version (23.10.1), which seems to contain breaking changes despite being a minor update
- [23.10.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.10.0) changes `executablePath` to no longer check if it exists, so the check is done in `findOrInstallBrowser` now (puppeteer/puppeteer#13340)
- puppeteer/puppeteer#13332 replaces the `PuppeteerLaunchOptions` type with a new `LaunchOptions` – the original type was accidentally removed rather than deprecated (fix in puppeteer/puppeteer#13376)

Updated all other dependencies with minor or patch changes