### PR TITLE
improve handling of load timeout and errors

### DIFF
--- a/.changeset/angry-balloons-tease.md
+++ b/.changeset/angry-balloons-tease.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+added `throwError` option to throw errors (and cause the build to fail) instead of just logging them

--- a/.changeset/angry-balloons-tease.md
+++ b/.changeset/angry-balloons-tease.md
@@ -2,4 +2,4 @@
 'astro-pdf': minor
 ---
 
-added `throwError` option to throw errors (and cause the build to fail) instead of just logging them
+added `throwOnFail` page option to throw an error if a page fails (and cause the build to fail) instead of just logging them

--- a/.changeset/fast-shoes-cry.md
+++ b/.changeset/fast-shoes-cry.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+added `maxRetries` page options to allow retrying the loading/processing of a page if an error occurs

--- a/.changeset/late-coats-wave.md
+++ b/.changeset/late-coats-wave.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+added `navTimeout` page option to set Puppeteer's default navigation timeout for the page

--- a/.changeset/tender-adults-sin.md
+++ b/.changeset/tender-adults-sin.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+add `maxConcurrent` option to specify the maximum number of pages to load and process at once. this can help prevent navigation timeouts caused when trying to load too many pages at the same time.

--- a/.changeset/tender-adults-sin.md
+++ b/.changeset/tender-adults-sin.md
@@ -2,4 +2,4 @@
 'astro-pdf': minor
 ---
 
-add `maxConcurrent` option to specify the maximum number of pages to load and process at once. this can help prevent navigation timeouts caused when trying to load too many pages at the same time.
+added `maxConcurrent` option to specify the maximum number of pages to load and process at once. this can help prevent navigation timeouts caused when trying to load too many pages at the same time.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ import pdf from 'astro-pdf'
 export default defineConfig({
     integrations: [
         pdf({
-            // specify base options as defaults for options pages dont return
+            // specify base options as defaults for pages
             baseOptions: {
                 path: '/pdf[pathname].pdf',
                 waitUntil: 'networkidle2',
+                maxRetries: 2,
                 ...
             },
+            // max number of pages to load at once
+            maxConcurrent: 2,
             // pages will receive the pathname of each page being built
             pages: {
                 '/some-page': '/pages/some.pdf', // output path
@@ -51,9 +54,13 @@ export default defineConfig({
                         path: 'example.pdf',
                         screen: true, // use screen media type instead of print
                         waitUntil: 'networkidle0', // for puppeteer page loading
+                        navTimeout: 40_000,
+                        maxRetries: 0,
+                        throwOnFail: true,
                         pdf: { // puppeteer PDFOptions
                             format: 'A4',
-                            printBackground: true
+                            printBackground: true,
+                            timeout: 20_000
                         }
                     },
                     'basic-example.pdf'

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Specifies options for generating each PDF. All options are optional when specify
 
     Options to be passed to [`Page.pdf`](https://pptr.dev/api/puppeteer.page.pdf) to specify how the PDF is generated.
 
+- **`maxRetries`**: `number`
+
+    Default: `0`
+
+    The maximum number of times to retry loading and processing a page if there is an error.
+
 - **`callback`**: `(page: Page) => void | Promise<void>` _(optional)_
 
     Receives a Puppeteer [`Page`]() after the page has loaded. This callback is run before the PDF is generated.

--- a/README.md
+++ b/README.md
@@ -125,12 +125,6 @@ export interface Options
 
     Default options to use for each page. Overrides the default options of [`PageOptions`](#pageoptions).
 
-- **`throwError`**: `boolean` _(optional)_
-
-    Set to throw errors encountered when loading and processing pages. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for a page.
-
-    By default, errors for failed pages will be logged and the build will still successfully complete.
-
 ### `PageOptions`
 
 ```ts
@@ -178,6 +172,14 @@ Specifies options for generating each PDF. All options are optional when specify
     Default: `0`
 
     The maximum number of times to retry loading and processing a page if there is an error.
+
+- **`throwError`**: `boolean`
+
+    Default: `false`
+
+    Set to throw errors encountered when loading and processing the page. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for the page.
+
+    By default, errors for failed pages will be logged and the build will still successfully complete.
 
 - **`callback`**: `(page: Page) => void | Promise<void>` _(optional)_
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Specifies options for generating each PDF. All options are optional when specify
 
     Used when Puppeteer is loading the page in [`Page.goto`](https://pptr.dev/api/puppeteer.page.goto)
 
+- **`navTimeout`**: `number` _(optional)_
+
+    Set the [default navigation timeout](https://pptr.dev/api/puppeteer.page.setdefaultnavigationtimeout) (in milliseconds) for Puppeteer. The default used by Puppeteer is 30 seconds. This can be set to 0 to have no timeout.
+
 - **`pdf`**: [`Omit<PDFOptions, 'path'>`](https://pptr.dev/api/puppeteer.pdfoptions)
 
     Default: `{}`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ export interface Options
 
     Specifies which pages in the site to convert to PDF and the options for each page.
 
+- **`maxConcurrent`**: `number` | `null` _(optional)_
+
+    Set the maximum number of pages to load and process at once. By default, all pages will be loaded in parallel, which may result in a Puppeteer navigation timeout if there are too many pages. If set to `null` or `undefined`, there will be no limit (which is the default behaviour).
+
 - **`install`**: `boolean` | [`Partial<InstallOptions>`](https://pptr.dev/browsers-api/browsers.installoptions) _(optional)_
 
     Specifies whether to install a browser, or options to pass to Puppeteer [`install`](https://pptr.dev/browsers-api/browsers.install). By default, it will install the latest stable build of Chrome if `install` is truthy and the browser to install is not specified.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ export interface Options
 
     Default options to use for each page. Overrides the default options of [`PageOptions`](#pageoptions).
 
+- **`throwError`**: `boolean` _(optional)_
+
+    Set to throw errors encountered when loading and processing pages. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for a page.
+
+    By default, errors for failed pages will be logged and the build will still successfully complete.
+
 ### `PageOptions`
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
             "dependencies": {
                 "@puppeteer/browsers": "^2.5.0",
                 "kleur": "^4.1.5",
+                "p-queue": "^8.0.1",
                 "puppeteer": "^23.10.1"
             },
             "devDependencies": {
@@ -2962,6 +2963,10 @@
             "resolved": "test/fixtures/build-pdf",
             "link": true
         },
+        "node_modules/@test/concurrent": {
+            "resolved": "test/fixtures/concurrent",
+            "link": true
+        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -5541,7 +5546,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
             "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/expect-type": {
@@ -8118,7 +8122,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
             "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eventemitter3": "^5.0.1",
@@ -8135,7 +8138,6 @@
             "version": "6.1.3",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
             "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.16"
@@ -12501,6 +12503,14 @@
             "name": "@test/build-pdf",
             "devDependencies": {
                 "@astrojs/check": "^0.9.4",
+                "astro": "^5.0.3",
+                "astro-pdf": "^1.3.0",
+                "typescript": "^5.6.2"
+            }
+        },
+        "test/fixtures/concurrent": {
+            "name": "@test/concurrent",
+            "devDependencies": {
                 "astro": "^5.0.3",
                 "astro-pdf": "^1.3.0",
                 "typescript": "^5.6.2"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@puppeteer/browsers": "^2.5.0",
         "kleur": "^4.1.5",
+        "p-queue": "^8.0.1",
         "puppeteer": "^23.10.1"
     },
     "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export default function pdf(options: Options): AstroIntegration {
                                     totalCount--
                                 }
 
-                                if (err instanceof PageError) {
+                                if (err instanceof PageError && (n > 0 || !options.throwError)) {
                                     const time = Date.now() - start
                                     const src = err.src ? dim(' ← ' + err.src) : ''
                                     logger.info(
@@ -143,6 +143,8 @@ export default function pdf(options: Options): AstroIntegration {
 
                                 if (n > 0) {
                                     await task()
+                                } else if (options.throwError) {
+                                    throw err
                                 }
                             }
                         }
@@ -153,6 +155,10 @@ export default function pdf(options: Options): AstroIntegration {
                 await browser.close()
                 if (typeof close === 'function') {
                     await close()
+                }
+                if (totalCount < queue.length) {
+                    const n = queue.length - totalCount
+                    logger.info(red(`Failed to generate ${n} page${n === 1 ? '' : 's'}`))
                 }
                 logger.info(green(`✓ Completed in ${Date.now() - startTime}ms.\n`))
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export default function pdf(options: Options): AstroIntegration {
                                     totalCount--
                                 }
 
-                                if (err instanceof PageError && (n > 0 || !options.throwError)) {
+                                if (err instanceof PageError && (n > 0 || !pageOptions.throwOnFail)) {
                                     const time = Date.now() - start
                                     const src = err.src ? dim(' ← ' + err.src) : ''
                                     logger.info(
@@ -143,7 +143,7 @@ export default function pdf(options: Options): AstroIntegration {
 
                                 if (n > 0) {
                                     await task()
-                                } else if (options.throwError) {
+                                } else if (pageOptions.throwOnFail) {
                                     throw err
                                 }
                             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,16 +124,20 @@ export default function pdf(options: Options): AstroIntegration {
                                 let retryInfo = ''
                                 const n = pageOptions.maxRetries ?? 0
                                 if (n > 0) {
-                                    retryInfo = yellow(` (${n} ${ n === 1 ? 'retry' : 'retries'} left)`)
+                                    retryInfo = yellow(` (${n} ${n === 1 ? 'retry' : 'retries'} left)`)
                                     pageOptions.maxRetries = n - 1
                                 } else {
                                     totalCount--
                                 }
-                                
+
                                 if (err instanceof PageError) {
                                     const time = Date.now() - start
                                     const src = err.src ? dim(' ← ' + err.src) : ''
-                                    logger.info(red(`✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${retryInfo}`))
+                                    logger.info(
+                                        red(
+                                            `✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${retryInfo}`
+                                        )
+                                    )
                                 }
                                 logger.debug(bold(red(`error while processing ${location}: `)) + err)
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export interface Options {
     baseOptions?: Partial<PageOptions>
     server?: ((config: AstroConfig) => ServerOutput | Promise<ServerOutput>) | false
     pages: PagesFunction | PagesMap
+    maxConcurrent?: number | null
 }
 
 export type PagesEntry = Partial<PageOptions> | string | boolean | null | undefined | void

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ export interface Options {
     server?: ((config: AstroConfig) => ServerOutput | Promise<ServerOutput>) | false
     pages: PagesFunction | PagesMap
     maxConcurrent?: number | null
+    throwError?: boolean
 }
 
 export type PagesEntry = Partial<PageOptions> | string | boolean | null | undefined | void

--- a/src/options.ts
+++ b/src/options.ts
@@ -25,6 +25,7 @@ export interface PageOptions {
     path: string | ((url: URL) => string)
     screen: boolean
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]
+    navTimeout?: number
     pdf: Omit<PDFOptions, 'path'>
     maxRetries?: number
     callback?: (page: Page) => void | Promise<void>

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,7 +11,6 @@ export interface Options {
     server?: ((config: AstroConfig) => ServerOutput | Promise<ServerOutput>) | false
     pages: PagesFunction | PagesMap
     maxConcurrent?: number | null
-    throwError?: boolean
 }
 
 export type PagesEntry = Partial<PageOptions> | string | boolean | null | undefined | void
@@ -29,6 +28,7 @@ export interface PageOptions {
     navTimeout?: number
     pdf: Omit<PDFOptions, 'path'>
     maxRetries?: number
+    throwOnFail?: boolean
     callback?: (page: Page) => void | Promise<void>
 }
 
@@ -37,7 +37,8 @@ export const defaultPageOptions: PageOptions = {
     screen: false,
     waitUntil: 'networkidle2',
     pdf: {},
-    maxRetries: 0
+    maxRetries: 0,
+    throwOnFail: false
 } as const
 
 export type CleanedMap = Record<string, Exclude<PagesEntry, null | undefined>[]>

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,6 +26,7 @@ export interface PageOptions {
     screen: boolean
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]
     pdf: Omit<PDFOptions, 'path'>
+    maxRetries?: number
     callback?: (page: Page) => void | Promise<void>
 }
 
@@ -33,7 +34,8 @@ export const defaultPageOptions: PageOptions = {
     path: '[pathname].pdf',
     screen: false,
     waitUntil: 'networkidle2',
-    pdf: {}
+    pdf: {},
+    maxRetries: 0
 } as const
 
 export type CleanedMap = Record<string, Exclude<PagesEntry, null | undefined>[]>

--- a/src/page.ts
+++ b/src/page.ts
@@ -59,7 +59,7 @@ export async function processPage(location: string, pageOptions: PageOptions, en
 
     debug(`starting processing of ${location}`)
 
-    const page = await loadPage(location, baseUrl, browser, pageOptions.waitUntil)
+    const page = await loadPage(location, baseUrl, browser, pageOptions.waitUntil, pageOptions.navTimeout)
 
     if (pageOptions.screen) {
         await page.emulateMediaType('screen')
@@ -113,9 +113,13 @@ export async function loadPage(
     location: string,
     baseUrl: URL | undefined,
     browser: Browser,
-    waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]
+    waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[],
+    navTimeout?: number
 ): Promise<Page> {
     const page = await browser.newPage()
+    if (typeof navTimeout === 'number') {
+        page.setDefaultNavigationTimeout(navTimeout)
+    }
     return new Promise((resolve, reject) => {
         let url: URL
         try {

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -17,9 +17,10 @@ export default defineConfig({
         pdf({
             pages,
             baseOptions: {
-                waitUntil: 'networkidle0'
+                waitUntil: 'networkidle0',
+                maxRetries: 2
             },
-            maxConcurrent: 5
+            maxConcurrent: null //40
         })
     ]
 })

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -17,8 +17,9 @@ export default defineConfig({
         pdf({
             pages,
             baseOptions: {
-                waitUntil: 'networkidle0',
-                maxRetries: 2
+                waitUntil: 'networkidle0'
+                //maxRetries: 2
+                //navTimeout: 0
             },
             maxConcurrent: null //40
         })

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'astro/config'
+
+import pdf, { PagesMap } from 'astro-pdf'
+
+const N = 80
+
+const url = 'https://en.wikipedia.org/wiki/Special:RandomInCategory?wpcategory=Featured+articles'
+
+const pages: PagesMap = {
+    [url]: Array(N)
+        .fill(0)
+        .map((_, i) => `random-${i}.pdf`)
+}
+
+export default defineConfig({
+    integrations: [
+        pdf({
+            pages,
+            baseOptions: {
+                waitUntil: 'networkidle0'
+            },
+            maxConcurrent: 5
+        })
+    ]
+})

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -17,11 +17,11 @@ export default defineConfig({
         pdf({
             pages,
             baseOptions: {
-                waitUntil: 'networkidle0'
+                waitUntil: 'networkidle0',
                 //maxRetries: 2
                 //navTimeout: 0
+                throwOnFail: true
             },
-            throwError: true,
             maxConcurrent: null //40
         })
     ]

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
                 //maxRetries: 2
                 //navTimeout: 0
             },
+            throwError: true,
             maxConcurrent: null //40
         })
     ]

--- a/test/fixtures/concurrent/package.json
+++ b/test/fixtures/concurrent/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@test/concurrent",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "build": "astro build"
+    },
+    "devDependencies": {
+        "astro": "^5.0.3",
+        "astro-pdf": "^1.3.0",
+        "typescript": "^5.6.2"
+    }
+}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -25,7 +25,10 @@ describe('run integration', () => {
                     }
                 },
                 '/': [true, true, 'index.pdf', 'copy.pdf'],
-                '/missing': 'missing.pdf'
+                '/missing': {
+                    path: 'missing.pdf',
+                    maxRetries: 2
+                }
             }
         })
     })

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -57,7 +57,7 @@ describe('load errors', () => {
         const fn = loadPage('/page.html', base, browser, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
-        expect(Date.now() - start).toBeLessThan(1000)
+        expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('redirect to 404 page', async () => {
@@ -65,7 +65,7 @@ describe('load errors', () => {
         const fn = loadPage('/page2.html', base, browser, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
-        expect(Date.now() - start).toBeLessThan(1000)
+        expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('empty status message', async () => {
@@ -73,7 +73,7 @@ describe('load errors', () => {
         const fn = loadPage('/403', base, browser, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/403', '403'))
-        expect(Date.now() - start).toBeLessThan(1000)
+        expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('unresolved hostname', async () => {
@@ -81,7 +81,7 @@ describe('load errors', () => {
         const fn = loadPage(location, undefined, browser, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
-        expect(Date.now() - start).toBeLessThan(1000)
+        expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('redirect to unresolved hostname', async () => {
@@ -90,7 +90,7 @@ describe('load errors', () => {
         const fn = loadPage('/outside', base, browser, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
-        expect(Date.now() - start).toBeLessThan(1000)
+        expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('about:blank', async () => {


### PR DESCRIPTION
added options to allow more control over load timeouts and errors

`Options`:
- `maxConcurrent`: limit the number of page loads to run at once

`PageOptions`:
- `maxRetries`: allow retries when a page fails
- `navTimeout`: set the default puppeteer navigation timeout
- `throwOnFail`: cause the whole build to fail if the page fails

these changes should help prevent the issues described in #60 