### PR TITLE
improve logging for retries and pdf write errors

### DIFF
--- a/.changeset/friendly-wasps-poke.md
+++ b/.changeset/friendly-wasps-poke.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+log current and max attempts for retries and error message for pdf write errors

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Specifies options for generating each PDF. All options are optional when specify
 
     The maximum number of times to retry loading and processing a page if there is an error.
 
-- **`throwError`**: `boolean`
+- **`throwOnFail`**: `boolean`
 
     Default: `false`
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -86,7 +86,8 @@ export async function processPage(location: string, pageOptions: PageOptions, en
 
         await pipeToFd(stream, fd)
     } catch (err) {
-        throw new PageError(dest, 'failed to write pdf', { cause: err, src: location })
+        const info = err instanceof Error ? ': ' + err.message : ''
+        throw new PageError(dest, 'failed to write pdf' + info, { cause: err, src: location })
     } finally {
         await fd.close()
     }

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
         pdf({
             pages,
             baseOptions: {
-                waitUntil: 'networkidle0',
+                waitUntil: 'networkidle0'
                 //maxRetries: 2
                 //navTimeout: 0
                 //throwOnFail: true

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -9,7 +9,8 @@ const url = 'https://en.wikipedia.org/wiki/Special:RandomInCategory?wpcategory=F
 const pages: PagesMap = {
     [url]: Array(N)
         .fill(0)
-        .map((_, i) => `random-${i}.pdf`)
+        .map((_, i) => `random-${i}.pdf`),
+    'https://fake.example.com': 'fake.pdf'
 }
 
 export default defineConfig({
@@ -20,7 +21,7 @@ export default defineConfig({
                 waitUntil: 'networkidle0',
                 //maxRetries: 2
                 //navTimeout: 0
-                throwOnFail: true
+                //throwOnFail: true
             },
             maxConcurrent: null //40
         })


### PR DESCRIPTION
- log both the current and max attempt count for retries: `(2 retries left)` -> `(1/3 attempts)`
- log the error message for pdf write errors instead of just `failed to write pdf`

fixed wrong option name in readme for throwOnFail