### PR TITLE
fix tests on ubuntu 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
             - name: Configure Puppeteer sandbox (Linux only)
               if: matrix.os == 'ubuntu-latest'
-              run: CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox
+              run: export CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Configure Puppeteer sandbox (Linux only)
+              if: matrix.os == 'ubuntu-latest'
+              run: CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox
+
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
 
             - name: Install Dependencies
               run: npm install
+            
+            - name: Check executablePath
+              run: node <<< "console.log(require('puppeteer').executablePath())"
 
             - name: Build Package
               run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  PUPPETEER_PATH={$HOME/.cache/puppeteer,$PWD/**/node_modules/.astro}/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_PATH={$HOME/.cache/puppeteer,$PWD/test/fixtures/*/node_modules/.astro}/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,14 @@ jobs:
                   abi <abi/4.0>,
                   include <tunables/global>
 
-                  profile chrome $PUPPETEER_SYSTEM $PUPPETEER_LOCAL flags=(unconfined) {
+                  profile chrome $PUPPETEER_SYSTEM flags=(unconfined) {
+                    userns,
+
+                    # Site-specific additions and overrides. See local/README for details.
+                    include if exists <local/chrome>
+                  }
+                  
+                  profile chrome-local $PUPPETEER_LOCAL flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.
@@ -86,10 +93,7 @@ jobs:
                   }
                   EOF
                   sudo apparmor_parser -r /etc/apparmor.d/chrome-dev-builds
-                  echo parsed
                   sudo service apparmor reload
-                  systemctl status apparmor.service
-                  journalctl -xeu apparmor.service
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,20 +72,24 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  PUPPETEER_PATH={$HOME/.cache/puppeteer,$PWD/test/fixtures/*/node_modules/.astro}/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_SYSTEM=$HOME/.cache/puppeteer/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_LOCAL=$PWD/test/fixtures/*/node_modules/.astro/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
 
-                  profile chrome $PUPPETEER_PATH flags=(unconfined) {
+                  profile chrome $PUPPETEER_SYSTEM $PUPPETEER_LOCAL flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.
                     include if exists <local/chrome>
                   }
                   EOF
+                  sudo apparmor_parser -r /etc/apparmor.d/chrome-dev-builds
+                  echo parsed
                   sudo service apparmor reload
-                  cat /etc/apparmor.d/chrome-dev-builds
+                  systemctl status apparmor.service
+                  journalctl -xeu apparmor.service
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,12 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  PUPPETEER_SYSTEM=/@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome
-                  PUPPETEER_LOCAL=$PWD/**/node_modules/.astro/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_PATH={$HOME/.cache/puppeteer,$PWD/**/node_modules/.astro}/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
 
-                  profile chrome $PUPPETEER_SYSTEM $PUPPETEER_LOCAL flags=(unconfined) {
+                  profile chrome $PUPPETEER_PATH flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
               if: matrix.os == 'ubuntu-latest'
               run: |
                   export CHROMIUM_BUILD_PATH=/@{HOME}/chromium/src/out/**/chrome
-                  cat | sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
+                  sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
 
@@ -84,7 +84,9 @@ jobs:
                     include if exists <local/chrome>
                   }
                   EOF
-                  sudo service apparmor reload  # reload AppArmor profiles to include the new one
+                  sudo service apparmor reload
+                  cat /etc/apparmor.d/chrome-dev-builds
+                  sudo apparmor_parser -r /etc/apparmor.d/chrome-dev-builds
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,13 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  export CHROMIUM_BUILD_PATH=/@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_SYSTEM=/@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome
+                  PUPPETEER_LOCAL=$PWD/**/node_modules/.astro/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
 
-                  profile chrome $CHROMIUM_BUILD_PATH flags=(unconfined) {
+                  profile chrome $PUPPETEER_SYSTEM $PUPPETEER_LOCAL flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  export CHROMIUM_BUILD_PATH=/@{HOME}/chromium/src/out/**/chrome
+                  export CHROMIUM_BUILD_PATH=/@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
@@ -86,7 +86,6 @@ jobs:
                   EOF
                   sudo service apparmor reload
                   cat /etc/apparmor.d/chrome-dev-builds
-                  sudo apparmor_parser -r /etc/apparmor.d/chrome-dev-builds
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4
@@ -96,7 +95,7 @@ jobs:
 
             - name: Install Dependencies
               run: npm install
-            
+
             - name: Check executablePath
               run: node <<< "console.log(require('puppeteer').executablePath())"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,20 +72,18 @@ jobs:
             - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  PUPPETEER_SYSTEM=$HOME/.cache/puppeteer/chrome/*/chrome-linux64/chrome
-                  PUPPETEER_LOCAL=$PWD/test/fixtures/*/node_modules/.astro/chrome/*/chrome-linux64/chrome
                   sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
                   abi <abi/4.0>,
                   include <tunables/global>
 
-                  profile chrome $PUPPETEER_SYSTEM flags=(unconfined) {
+                  profile chrome $HOME/.cache/puppeteer/chrome/*/chrome-linux64/chrome flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.
                     include if exists <local/chrome>
                   }
-                  
-                  profile chrome-local $PUPPETEER_LOCAL flags=(unconfined) {
+
+                  profile chrome-local $PWD/test/fixtures/*/node_modules/.astro/chrome/*/chrome-linux64/chrome flags=(unconfined) {
                     userns,
 
                     # Site-specific additions and overrides. See local/README for details.
@@ -103,9 +101,6 @@ jobs:
 
             - name: Install Dependencies
               run: npm install
-
-            - name: Check executablePath
-              run: node <<< "console.log(require('puppeteer').executablePath())"
 
             - name: Build Package
               run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,22 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Configure Puppeteer sandbox (Linux only)
+            - name: Configure AppArmor profile for Puppeteer (Linux only)
               if: matrix.os == 'ubuntu-latest'
-              run: export CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox
+              run: |
+                  export CHROMIUM_BUILD_PATH=/@{HOME}/chromium/src/out/**/chrome
+                  cat | sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
+                  abi <abi/4.0>,
+                  include <tunables/global>
+
+                  profile chrome $CHROMIUM_BUILD_PATH flags=(unconfined) {
+                    userns,
+
+                    # Site-specific additions and overrides. See local/README for details.
+                    include if exists <local/chrome>
+                  }
+                  EOF
+                  sudo service apparmor reload  # reload AppArmor profiles to include the new one
 
             - name: Setup node@${{ matrix.node-version }}
               uses: actions/setup-node@v4


### PR DESCRIPTION
`ubuntu-latest` test runner has been updated to Ubuntu 24 which can cause issues due to security features
https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu

- added a step in ci.yml that creates AppArmor profiles that allow the chrome executable in puppeteer's user cache and local installations of chrome in test fixtures to run