### PR TITLE
ensure pages and browser are closed properly

### DIFF
--- a/.changeset/little-papayas-watch.md
+++ b/.changeset/little-papayas-watch.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+Ensure that all pages and the browser are closed properly when errors are encountered

--- a/test/concurrent.test.ts
+++ b/test/concurrent.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeAll } from 'vitest'
+
+import { mkdir } from 'node:fs/promises'
+
+import { build } from 'astro'
+import type { Page } from 'puppeteer'
+
+import pdf from 'astro-pdf'
+
+describe('max concurrent pages', () => {
+    const calls: number[] = []
+    beforeAll(async () => {
+        const root = './test/fixtures/.cache/concurrent'
+        await mkdir(root, { recursive: true })
+
+        async function callback(page: Page) {
+            calls.push((await page.browser().pages()).length)
+        }
+
+        await build({
+            logLevel: 'silent',
+            root,
+            integrations: [
+                pdf({
+                    baseOptions: {
+                        waitUntil: 'load',
+                        callback
+                    },
+                    pages: {
+                        'https://en.wikipedia.org/wiki/Special:Random': Array(4).fill('random.pdf'),
+                        'https://example.com/not/a/real/page': {
+                            path: 'fake.pdf',
+                            maxRetries: 1
+                        },
+                        'https://not.a.real.subdomain.example.com': {
+                            path: 'fake.pdf',
+                            maxRetries: 1
+                        },
+                        'https://example.com': Array(2).fill('example.pdf')
+                    },
+                    maxConcurrent: 2
+                })
+            ]
+        })
+    }, 30_000)
+
+    test('has at most 2 pages open at once', () => {
+        expect(calls.length).toBe(6) // only successfully loaded pages call the callback
+        expect(calls.every((n) => n <= 2)).toBe(true)
+    })
+})

--- a/test/fixtures/build-pdf/astro.config.mjs
+++ b/test/fixtures/build-pdf/astro.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { defineConfig } from 'astro/config'
 
 import astroPdf from 'astro-pdf'

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -5,7 +5,7 @@ import { cp, lstat, mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { AstroConfig, AstroIntegration } from 'astro'
+import { AstroConfig, AstroIntegration, build } from 'astro'
 
 import pdf from 'astro-pdf'
 
@@ -93,7 +93,6 @@ describe('run integration', () => {
             })
         }, 30000)
 
-        // TODO check runBefore runAfter
         test('called runBefore', () => {
             expect(runBefore).toBeCalledTimes(1)
             expect(runBefore).toHaveBeenCalledWith(outDir)
@@ -145,4 +144,25 @@ describe('run integration', () => {
             expect(existsSync(path)).toBe(false)
         })
     })
+})
+
+describe('throw on fail', () => {
+    test('causes build to fail with throwOnFail', async () => {
+        const promise = build({
+            logLevel: 'silent',
+            root: 'test/fixtures/.cache/throw-on-fail',
+            integrations: [
+                pdf({
+                    baseOptions: {
+                        waitUntil: 'load',
+                        throwOnFail: true
+                    },
+                    pages: {
+                        'https://example.com/not/a/real/page.php': true
+                    }
+                })
+            ]
+        })
+        await expect(promise).rejects.toThrow('Failed to load')
+    }, 10000)
 })

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -1,15 +1,13 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
-import { Server } from 'node:http'
-
 import { Browser, launch } from 'puppeteer'
 
 import { loadPage, PageError } from 'astro-pdf/dist/page.js'
 
-import { start } from './utils/server.js'
+import { start, TestServer } from './utils/server.js'
 
 describe('load errors', () => {
-    let server: Server
+    let server: TestServer
     let port: number
     let browser: Browser
 
@@ -29,73 +27,83 @@ describe('load errors', () => {
     })
 
     test('relative path with no base url', async () => {
-        const fn = loadPage('/page.html', undefined, browser, 'load')
+        const page = await browser.newPage()
+        const fn = loadPage('/page.html', undefined, page, 'load')
         await expect(fn).rejects.toThrowError(new PageError('/page.html', 'invalid location'))
     })
 
     test('invalid url', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('https://[pathname]', base, browser, 'load')
+        const fn = loadPage('https://[pathname]', base, page, 'load')
         await expect(fn).rejects.toThrowError(new PageError('https://[pathname]', 'invalid location'))
     })
 
     test('valid page', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const page = await loadPage('/index.html', base, browser, 'networkidle0')
+        await loadPage('/index.html', base, page, 'networkidle0')
         expect(page.url()).toBe(new URL('/index.html', base).href)
         expect(await page.content()).toContain('<h1>Page Loaded!</h1>')
     })
 
     test('redirect to valid page', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const page = await loadPage('/other.html', base, browser, 'networkidle0')
+        await loadPage('/other.html', base, page, 'networkidle0')
         expect(page.url()).toBe(new URL('/index.html', base).href)
     })
 
     test('404 page', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('/page.html', base, browser, 'networkidle0')
+        const fn = loadPage('/page.html', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
         expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('redirect to 404 page', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('/page2.html', base, browser, 'networkidle0')
+        const fn = loadPage('/page2.html', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
         expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('empty status message', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('/403', base, browser, 'networkidle0')
+        const fn = loadPage('/403', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/403', '403'))
         expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('unresolved hostname', async () => {
+        const page = await browser.newPage()
         const location = 'https://fake-gxcskbrl.example.com/page.html'
-        const fn = loadPage(location, undefined, browser, 'networkidle0')
+        const fn = loadPage(location, undefined, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
         expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('redirect to unresolved hostname', async () => {
+        const page = await browser.newPage()
         const location = 'https://fake-gxcskbrl.example.com/page.html'
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('/outside', base, browser, 'networkidle0')
+        const fn = loadPage('/outside', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
         expect(Date.now() - start).toBeLessThan(1200)
     })
 
     test('about:blank', async () => {
+        const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
-        const fn = loadPage('about:blank', base, browser, 'load')
+        const fn = loadPage('about:blank', base, page, 'load')
         await expect(fn).rejects.toThrowError('did not navigate')
     })
 

--- a/test/max-retries.test.ts
+++ b/test/max-retries.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeAll } from 'vitest'
+
+import { pathToFileURL } from 'node:url'
+
+import { build } from 'astro'
+
+import pdf from 'astro-pdf'
+
+import { start, TestServer } from './utils/server.js'
+
+describe('retries failed load', () => {
+    let server: TestServer
+
+    beforeAll(async () => {
+        server = await start(pathToFileURL('test/fixtures/.cache/max-retries/public/'), {
+            '/b': {
+                dest: 'https://super.fake.example.com'
+            },
+            '/c': {
+                dest: 'https://example.com'
+            },
+            '/d': {
+                dest: 'https://en.wikipedia.org/wiki/Special:Random'
+            }
+        })
+        const address = server.address()
+        if (!address || typeof address !== 'object') {
+            throw new Error('test error: invalid server address')
+        }
+        const url = new URL('http://localhost:' + address.port)
+        await build({
+            logLevel: 'silent',
+            root: 'test/fixtures/.cache/max-retries',
+            integrations: [
+                pdf({
+                    baseOptions: {
+                        waitUntil: 'load',
+                        maxRetries: 2
+                    },
+                    pages: {
+                        [new URL('a', url).href]: 'a.pdf',
+                        [new URL('b', url).href]: 'b.pdf',
+                        [new URL('c', url).href]: 'c.pdf',
+                        [new URL('d', url).href]: 'd.pdf'
+                    }
+                })
+            ]
+        })
+    })
+
+    test('requests each failed page 3 times', () => {
+        expect(server.history.filter((req) => req.url === '/a').length).toBe(3)
+        expect(server.history.filter((req) => req.url === '/b').length).toBe(3)
+    })
+    test('requests each successful page 1 time', () => {
+        expect(server.history.filter((req) => req.url === '/c').length).toBe(1)
+        expect(server.history.filter((req) => req.url === '/d').length).toBe(1)
+    })
+})

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -1,8 +1,7 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
 import { existsSync } from 'node:fs'
 import { lstat, rm } from 'node:fs/promises'
-import { Server } from 'node:http'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -13,10 +12,10 @@ import { defaultPathFunction, PageOptions } from 'astro-pdf/dist/options.js'
 import { PageEnv, PageError, PageResult, processPage } from 'astro-pdf/dist/page.js'
 
 import { parsePdf } from './utils/index.js'
-import { start } from './utils/server.js'
+import { start, TestServer } from './utils/server.js'
 
 describe('process page', () => {
-    let server: Server
+    let server: TestServer
     let env: PageEnv
 
     beforeAll(async () => {
@@ -36,6 +35,7 @@ describe('process page', () => {
             outDir: fileURLToPath(new URL('./dist/', root)),
             debug: () => {}
         }
+        await Promise.all((await env.browser.pages()).map((page) => page.close()))
         if (existsSync(env.outDir)) {
             await rm(env.outDir, { recursive: true })
         }
@@ -164,5 +164,13 @@ describe('process page', () => {
         const pathnames = [results[0].output.pathname, results[1].output.pathname]
         expect(pathnames).toContain('/output.pdf')
         expect(pathnames).toContain('/output-1.pdf')
+    })
+
+    afterAll(async () => {
+        const n = (await env.browser.pages()).length
+        await env.browser.close()
+        if (n > 0) {
+            throw new Error(`${n} pages were left open by processPage`)
+        }
     })
 })

--- a/test/utils/server.ts
+++ b/test/utils/server.ts
@@ -10,18 +10,30 @@ export interface Redirects {
     }
 }
 
-export function start(root: URL, redirects?: Redirects, timeout = 5000) {
-    const server = new Server(makeHandler(root, redirects ?? {}))
-    server.listen()
-    return new Promise<Server>((resolve, reject) => {
-        const tid = setTimeout(() => {
-            reject(new Error(`server start timed out in ${timeout}ms`))
-        }, timeout)
-        server.on('listening', () => {
-            clearTimeout(tid)
-            resolve(server)
+export class TestServer extends Server {
+    history: IncomingMessage[]
+    constructor(root: URL, redirects?: Redirects) {
+        const history: IncomingMessage[] = []
+        super(makeHandler(root, redirects ?? {}, history))
+        this.history = history
+    }
+    async start(timeout = 5000) {
+        this.listen()
+        return new Promise<TestServer>((resolve, reject) => {
+            const tid = setTimeout(() => {
+                reject(new Error(`server start timed out in ${timeout}ms`))
+            }, timeout)
+            this.on('listening', () => {
+                clearTimeout(tid)
+                resolve(this)
+            })
         })
-    })
+    }
+}
+
+export async function start(root: URL, redirects?: Redirects, timeout?: number) {
+    const server = new TestServer(root, redirects)
+    return await server.start(timeout)
 }
 
 function wait(timeout: number) {
@@ -41,8 +53,9 @@ async function isFile(path: string) {
     }
 }
 
-function makeHandler(root: URL, redirects: Redirects) {
+function makeHandler(root: URL, redirects: Redirects, history: IncomingMessage[] = []) {
     return async (req: IncomingMessage, res: ServerResponse) => {
+        history.push(req)
         if (req.url) {
             const url = new URL(req.url, 'base://')
             const delay = parseInt(url.searchParams.get('delay') || '0')


### PR DESCRIPTION
- use `try finally` to ensure that pages and browser are always closed when errors are thrown
- added tests for maxConcurrent and throwOnFail
- updated the test server util