### PR TITLE
add preCallback & browserCallback

### DIFF
--- a/.changeset/cool-cougars-doubt.md
+++ b/.changeset/cool-cougars-doubt.md
@@ -2,4 +2,4 @@
 'astro-pdf': minor
 ---
 
-Add `preCallback` page option to configure the Puppeter `Page` before navigation
+Add `preCallback` page option to configure the Puppeteer `Page` before navigation

--- a/.changeset/cool-cougars-doubt.md
+++ b/.changeset/cool-cougars-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+Add `preCallback` page option to configure the Puppeter `Page` before navigation

--- a/.changeset/three-brooms-whisper.md
+++ b/.changeset/three-brooms-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+Add `browserCallback` option to configure the Puppeteer `Browser` before any pages are processed

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ export interface Options
     const pdfUrl = new URL(pathnames[0], dir)
     ```
 
+- **`browserCallback`**: `(browser: Browser) => void | Promise<void>` _(optional)_
+
+    Receives a Puppeteer [`Browser`](https://pptr.dev/api/puppeteer.browser) after it is launched. This can be used to configure the browser before any pages are processed.
+
 ### `PageOptions`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ Specifies options for generating each PDF. All options are optional when specify
 
     By default, errors for failed pages will be logged and the build will still successfully complete.
 
+- **`preCallback`**: `(page: Page) => void | Promise<void>` _(optional)_
+
+    Receives a Puppeteer [`Page`](https://pptr.dev/api/puppeteer.page) before any navigation is done. This can be used, for example, to set the [user agent](https://pptr.dev/api/puppeteer.page.setuseragent), or [HTTP headers](https://pptr.dev/api/puppeteer.page.setextrahttpheaders) for the request.
+
 - **`callback`**: `(page: Page) => void | Promise<void>` _(optional)_
 
     Receives a Puppeteer [`Page`](https://pptr.dev/api/puppeteer.page) after the page has loaded. This callback is run before the PDF is generated.

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,9 @@ export default function pdf(options: Options): AstroIntegration {
                 }
 
                 try {
+                    if (typeof options.browserCallback === 'function') {
+                        await options.browserCallback(browser)
+                    }
                     await pMap(queue, ({ location, pageOptions }) => task(location, pageOptions), {
                         concurrency: options.maxConcurrent ?? Number.POSITIVE_INFINITY
                     })

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,6 +32,7 @@ export interface PageOptions {
     pdf: Omit<PDFOptions, 'path'>
     maxRetries?: number
     throwOnFail?: boolean
+    preCallback?: (page: Page) => void | Promise<void>
     callback?: (page: Page) => void | Promise<void>
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { InstallOptions } from '@puppeteer/browsers'
 import type { AstroConfig } from 'astro'
-import type { Page, PDFOptions, LaunchOptions, PuppeteerLifeCycleEvent, Viewport } from 'puppeteer'
+import type { Page, PDFOptions, LaunchOptions, PuppeteerLifeCycleEvent, Viewport, Browser } from 'puppeteer'
 
 import type { ServerOutput } from './server.js'
 
@@ -13,6 +13,7 @@ export interface Options {
     maxConcurrent?: number | null
     runBefore?: (dir: URL) => void | Promise<void>
     runAfter?: (dir: URL, pathnames: string[]) => void | Promise<void>
+    browserCallback?: (browser: Browser) => void | Promise<void>
 }
 
 export type PagesEntry = Partial<PageOptions> | string | boolean | null | undefined | void

--- a/src/page.ts
+++ b/src/page.ts
@@ -87,7 +87,7 @@ export async function processPage(location: string, pageOptions: PageOptions, en
     const page = await newPage(browser, location)
 
     try {
-        await loadPage(location, baseUrl, page, pageOptions.waitUntil, pageOptions.viewport, pageOptions.navTimeout)
+        await loadPage(location, baseUrl, page, pageOptions.waitUntil, pageOptions.viewport, pageOptions.navTimeout, pageOptions.preCallback)
 
         if (pageOptions.screen) {
             await page.emulateMediaType('screen')
@@ -154,7 +154,8 @@ export async function loadPage(
     page: Page,
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[],
     viewport?: Viewport,
-    navTimeout?: number
+    navTimeout?: number,
+    preCallback?: (page: Page) => void | Promise<void>
 ): Promise<Page> {
     if (page.url() !== 'about:blank' || page.isClosed()) {
         throw new Error(`internal error: loadPage expects a new page`)
@@ -163,10 +164,13 @@ export async function loadPage(
     if (viewport) {
         await page.setViewport(viewport)
     }
-
     if (typeof navTimeout === 'number') {
         page.setDefaultNavigationTimeout(navTimeout)
     }
+    if (typeof preCallback === 'function') {
+        await preCallback(page)
+    }
+
     return new Promise((resolve, reject) => {
         let url: URL
         try {

--- a/src/page.ts
+++ b/src/page.ts
@@ -87,7 +87,15 @@ export async function processPage(location: string, pageOptions: PageOptions, en
     const page = await newPage(browser, location)
 
     try {
-        await loadPage(location, baseUrl, page, pageOptions.waitUntil, pageOptions.viewport, pageOptions.navTimeout, pageOptions.preCallback)
+        await loadPage(
+            location,
+            baseUrl,
+            page,
+            pageOptions.waitUntil,
+            pageOptions.viewport,
+            pageOptions.navTimeout,
+            pageOptions.preCallback
+        )
 
         if (pageOptions.screen) {
             await page.emulateMediaType('screen')

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
-import { Browser, launch } from 'puppeteer'
+import { Browser, launch, Viewport } from 'puppeteer'
 
 import { loadPage, PageError } from 'astro-pdf/dist/page.js'
 
@@ -113,6 +113,21 @@ describe('load page', () => {
         const base = new URL('http://localhost:' + port)
         const fn = loadPage('/index.html', base, page, 'load')
         await expect(fn).rejects.toThrowError('internal error: loadPage expects a new page')
+    })
+
+    test('runs preCallback after setting viewport and nav timeout', async () => {
+        const page = await browser.newPage()
+        const base = new URL('http://localhost:' + port)
+        let pass = false
+        const viewport: Viewport = {
+            width: 111,
+            height: 99,
+            deviceScaleFactor: 1
+        }
+        await loadPage('/index.html', base, page, 'load', viewport, 12345, async (page) => {
+            pass = page.viewport() === viewport && page.getDefaultNavigationTimeout() === 12345
+        })
+        expect(pass).toBe(true)
     })
 
     afterAll(async () => {


### PR DESCRIPTION
- added `preCallback` page option, which is like `callback` but run before the page is loaded
- added `browserCallback` option which is run before any pages are processed
- added tests for both new options