### PR TITLE
add `isolated` page option

### DIFF
--- a/.changeset/nice-squids-behave.md
+++ b/.changeset/nice-squids-behave.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+Added `isolated` page option to create a new browser context for that page which will not share cookies and cache with other pages

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/lameuler/astro-pdf/actions/workflows/ci.yml/badge.svg)](https://github.com/lameuler/astro-pdf/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/astro-pdf)](https://www.npmjs.com/package/astro-pdf)
 
-A simple Astro integration to generate PDFs from built pages. Generate PDF versions of pages in your Astro site, or pages on external sites. Note that the PDFs will only be generated during builds and not when running the dev server.
+Astro integration to generate PDFs from any webpage. Generate PDF versions of pages in your Astro site, or pages on external sites. Note that the PDFs will only be generated during builds and not when running the dev server.
 
 ## Quickstart
 
@@ -67,7 +67,8 @@ export default defineConfig({
                             format: 'A4',
                             printBackground: true,
                             timeout: 20_000
-                        }
+                        },
+                        isolated: true // do not share cookies with other pages
                     },
                     'basic-example.pdf'
                 ],
@@ -216,6 +217,16 @@ Specifies options for generating each PDF. All options are optional when specify
     Set to throw errors encountered when loading and processing the page. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for the page.
 
     By default, errors for failed pages will be logged and the build will still successfully complete.
+
+- **`isolated`**: `boolean`
+
+    Default: `false`
+
+    If `isolated` is set to `true`, a new [`BrowserContext`](https://pptr.dev/api/puppeteer.browsercontext) will be created every time the page is loaded.
+
+    This is like opening the page in a new incognito window, and `isolated` pages will not share any cookies or cache with the other pages.
+
+    Otherwise, all other pages (with `isolated: false`) will be opened in the same browser context.
 
 - **`preCallback`**: `(page: Page) => void | Promise<void>` _(optional)_
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astro-pdf",
     "version": "1.6.0",
-    "description": "A simple Astro integration to generate PDFs from built pages",
+    "description": "Astro integration to generate PDFs from pages in your site and other websites",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/options.ts
+++ b/src/options.ts
@@ -33,6 +33,7 @@ export interface PageOptions {
     pdf: Omit<PDFOptions, 'path'>
     maxRetries?: number
     throwOnFail?: boolean
+    isolated?: boolean
     preCallback?: (page: Page) => void | Promise<void>
     callback?: (page: Page) => void | Promise<void>
 }
@@ -43,7 +44,8 @@ export const defaultPageOptions = {
     waitUntil: 'networkidle2',
     pdf: {},
     maxRetries: 0,
-    throwOnFail: false
+    throwOnFail: false,
+    isolated: false
 } satisfies PageOptions
 
 export type CleanedMap = Record<string, Exclude<PagesEntry, null | undefined>[]>

--- a/test/fixtures/build-pdf/astro.config.mjs
+++ b/test/fixtures/build-pdf/astro.config.mjs
@@ -35,7 +35,8 @@ export default defineConfig({
             pages: {
                 testing: {
                     path: '../testing4.pdf',
-                    pdf: { printBackground: true }
+                    pdf: { printBackground: true },
+                    isolated: true
                 },
                 testing2: { path: 'testing3/testing4/testing5/testing6.pdf' },
                 testing3: 'testing3/testing4/testing5/testing6.pdf',
@@ -44,7 +45,7 @@ export default defineConfig({
                 'https://ler.sg/to/fake.example.com': 'fake.pdf',
                 'https://example.com': true,
                 'https://developer.mozilla.org/404/page/not/found': true,
-                'https://ler.sg/cv': { pdf: { printBackground: true } },
+                'https://ler.sg/cv': { pdf: { printBackground: true }, isolated: true },
                 'http://eu.ler.sg/resume': true,
                 'http://ler.sg/to/ler.sg/cv': true,
                 fallback: (pathname) => pathname === '/index.html'

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -45,14 +45,14 @@ describe('load page', () => {
         await loadPage('/index.html', base, page, 'networkidle0')
         expect(page.url()).toBe(new URL('/index.html', base).href)
         expect(await page.content()).toContain('<h1>Page Loaded!</h1>')
-    })
+    }, 8000)
 
     test('redirect to valid page', async () => {
         const page = await browser.newPage()
         const base = new URL('http://localhost:' + port)
         await loadPage('/other.html', base, page, 'networkidle0')
         expect(page.url()).toBe(new URL('/index.html', base).href)
-    })
+    }, 8000)
 
     test('404 page', async () => {
         const page = await browser.newPage()
@@ -60,7 +60,7 @@ describe('load page', () => {
         const fn = loadPage('/page.html', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
-        expect(Date.now() - start).toBeLessThan(1200)
+        expect(Date.now() - start).toBeLessThan(1400)
     })
 
     test('redirect to 404 page', async () => {
@@ -69,7 +69,7 @@ describe('load page', () => {
         const fn = loadPage('/page2.html', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/page.html', '404 Not Found!!', { status: 404 }))
-        expect(Date.now() - start).toBeLessThan(1200)
+        expect(Date.now() - start).toBeLessThan(1400)
     })
 
     test('empty status message', async () => {
@@ -78,7 +78,7 @@ describe('load page', () => {
         const fn = loadPage('/403', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError('/403', '403'))
-        expect(Date.now() - start).toBeLessThan(1200)
+        expect(Date.now() - start).toBeLessThan(1400)
     })
 
     test('unresolved hostname', async () => {
@@ -87,7 +87,7 @@ describe('load page', () => {
         const fn = loadPage(location, undefined, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
-        expect(Date.now() - start).toBeLessThan(1200)
+        expect(Date.now() - start).toBeLessThan(1400)
     })
 
     test('redirect to unresolved hostname', async () => {
@@ -97,7 +97,7 @@ describe('load page', () => {
         const fn = loadPage('/outside', base, page, 'networkidle0')
         const start = Date.now()
         await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
-        expect(Date.now() - start).toBeLessThan(1200)
+        expect(Date.now() - start).toBeLessThan(1400)
     })
 
     test('about:blank', async () => {

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -171,7 +171,8 @@ describe('process page', () => {
             cookie = {
                 domain: 'localhost',
                 name: 'test:cookie',
-                value: 'G19onZSj8uRt1_9ttkHG5'
+                value: 'G19onZSj8uRt1_9ttkHG5',
+                expires: Math.round(Date.now() / 1000) + 86400
             }
             await env.browser.defaultBrowserContext().setCookie(cookie)
             console.log(await env.browser.cookies())

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -175,7 +175,6 @@ describe('process page', () => {
                 expires: Math.round(Date.now() / 1000) + 86400
             }
             await env.browser.defaultBrowserContext().setCookie(cookie)
-            console.log(await env.browser.cookies())
         })
         test('non-isolated page can see cookie', async () => {
             let hasCookie: boolean | null = null
@@ -190,7 +189,6 @@ describe('process page', () => {
                     async preCallback(page) {
                         sameContext = page.browserContext() === env.browser.defaultBrowserContext()
                         const cookies = await page.browserContext().cookies()
-                        console.log(cookies, await env.browser.cookies())
                         hasCookie = !!cookies.find(
                             ({ name, value, domain }) =>
                                 domain === cookie.domain && name === cookie.name && value === cookie.value


### PR DESCRIPTION
- added `isolated` page option which creates a new browser context for the page to not share any cookies
- added tests for `isolated` and ensured the created browser contexts are properly closed