### PR TITLE
allow async dynamic path

### DIFF
--- a/.changeset/many-gifts-tap.md
+++ b/.changeset/many-gifts-tap.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+added `page: Page` parameter to `path` option callback, and allow it to return a Promise. this can be used to dynamically set the PDF output path based on the page content

--- a/README.md
+++ b/README.md
@@ -166,15 +166,15 @@ export interface PageOptions
 
 Specifies options for generating each PDF. All options are optional when specifying pages in a [`PagesMap`](#pagesmap) or [`PagesFunction`](#pagesfunction). See [`PagesEntry`](#pagesentry) for more details.
 
-- **`path`**: `string` | `((url: URL) => string)`
+- **`path`**: `string` | `((url: URL, page: Page) => string | Promise<string>)`
 
     Default: `'[pathname].pdf'`
 
-    Specify the location where the PDF will be generated. This is treated like a `href` in the site, so absolute paths will be resolved relative to the root of the site. For example, `/path/to/file.pdf` and `path/to/file.pdf` are equivalent.
+    Specify the location where the PDF will be generated. This is treated like a `href` in the site, so absolute paths will be resolved relative to the root of the site. For example, `/path/to/file.pdf` and `path/to/file.pdf` are equivalent. If `path` contains certain special characters like `%`, you will need to encode those characters using [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) or [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 
     If the path contains `[pathname]`, it will be substituted for the pathname of the page generated e.g. `/path/to/page` will be substituted into `[pathname].pdf` to get `/path/to/page.pdf`. If there are any redirects, the pathname will be the final location that is used to generate the PDF.
 
-    `path` can also be a function which receives the URL of the page used to generate the PDF and returns the path where the PDF will be generated.
+    `path` can also be a function which receives the final URL of the page and the Puppeteer [`Page`](https://pptr.dev/api/puppeteer.page). The function can return the path where the PDF will be generated as a string, or a Promise which will resolve to the path. The `url` parameter is equivalent to getting `new URL(page.url())`.
 
     If there is already a file with the same name, a counter suffix will be added to prevent overwriting the file. For example: `example.pdf` then `example-1.pdf` then `example-2.pdf`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,17 +154,19 @@ export default function pdf(options: Options): AstroIntegration {
                                 error = new Error(
                                     `An unexpected error occurred and was not handled by astro-pdf while processing \`${location}\`:\n\n` +
                                         err +
-                                        '\n\nConsider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose',
+                                        '\n\nConsider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose\n',
                                     { cause: err }
                                 )
                             }
                             if (pageOptions.throwOnFail) {
                                 throw error
                             } else {
-                                if (error instanceof Error) {
-                                    const causeStack =
-                                        error.cause instanceof Error ? `${bold('Caused by:')}\n${error.cause.stack}` : ''
-                                    logger.error(error.stack + '\n\n' + causeStack)
+                                if (error instanceof Error && error.stack) {
+                                    if (error.cause instanceof Error) {
+                                        logger.error(`${error.stack}\n\n${bold('Caused by:')}\n${error.cause.stack}\n`)
+                                    } else {
+                                        logger.error(error.stack + '\n')
+                                    }
                                 } else {
                                     logger.error(error + '\n')
                                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,9 @@ export default function pdf(options: Options): AstroIntegration {
                                     red(`✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${attempts}`)
                                 )
                             }
-                            logger.debug(bold(red(`error while processing ${location}: `)) + err)
+                            const causeStack =
+                                err.cause instanceof Error ? `\n${bold('Caused by:')}\n${err.cause.stack}` : ''
+                            logger.debug(bold(red(`error while processing ${location}:\n`)) + err.stack + causeStack)
                         } else {
                             let error = err
                             if (!(err instanceof FatalError)) {
@@ -159,7 +161,13 @@ export default function pdf(options: Options): AstroIntegration {
                             if (pageOptions.throwOnFail) {
                                 throw error
                             } else {
-                                logger.error('build failed: ' + error + '\n')
+                                if (error instanceof Error) {
+                                    const causeStack =
+                                        error.cause instanceof Error ? `${bold('Caused by:')}\n${error.cause.stack}` : ''
+                                    logger.error(error.stack + '\n\n' + causeStack)
+                                } else {
+                                    logger.error(error + '\n')
+                                }
                                 throw INTERRUPT
                             }
                         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,8 +150,9 @@ export default function pdf(options: Options): AstroIntegration {
                             if (!(err instanceof FatalError)) {
                                 // wrap unexpected errors with a more useful message
                                 error = new Error(
-                                    `An unexpected error occurred and was not handled by astro-pdf while processing ${location}. ` +
-                                        'Consider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose',
+                                    `An unexpected error occurred and was not handled by astro-pdf while processing \`${location}\`:\n\n` +
+                                        err +
+                                        '\n\nConsider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose',
                                     { cause: err }
                                 )
                             }

--- a/src/options.ts
+++ b/src/options.ts
@@ -25,7 +25,7 @@ export type PagesMap = Record<string, PagesEntry | PagesEntry[]> & {
 }
 
 export interface PageOptions {
-    path: string | ((url: URL) => string)
+    path: string | ((url: URL, page: Page) => string | Promise<string>)
     screen: boolean
     viewport?: Viewport
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]

--- a/src/page.ts
+++ b/src/page.ts
@@ -114,7 +114,8 @@ export async function processPage(location: string, pageOptions: PageOptions, en
         const url = page.url()
         const dest = baseUrl && url.startsWith(baseUrl?.origin) ? url.substring(baseUrl?.origin.length) : url
 
-        const outPathRaw = typeof pageOptions.path === 'function' ? pageOptions.path(new URL(url)) : pageOptions.path
+        const outPathRaw =
+            typeof pageOptions.path === 'function' ? await pageOptions.path(new URL(url), page) : pageOptions.path
         // resolve pdf output relative to astro output directory
         const outPath = pathnameToFilepath(outPathRaw, outDir)
 

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -9,7 +9,18 @@ const url = 'https://en.wikipedia.org/wiki/Special:RandomInCategory?wpcategory=F
 const pages: PagesMap = {
     [url]: Array(N)
         .fill(0)
-        .map((_, i) => `random-${i}.pdf`),
+        .map(() => ({
+            async path(url, page) {
+                return (
+                    (await page.title())
+                        .toLowerCase()
+                        .replace(/wikipedia\s*$/, '')
+                        .replaceAll(/[^a-z0-9\s]/g, '')
+                        .trim()
+                        .replaceAll(/\s+/, '-') + '.pdf'
+                )
+            }
+        })),
     'https://fake.example.com': 'fake.pdf'
 }
 

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -17,7 +17,7 @@ const pages: PagesMap = {
                         .replace(/wikipedia\s*$/, '')
                         .replaceAll(/[^a-z0-9\s]/g, '')
                         .trim()
-                        .replaceAll(/\s+/, '-') + '.pdf'
+                        .replaceAll(/\s+/g, '-') + '.pdf'
                 )
             }
         })),

--- a/test/page-options.test.ts
+++ b/test/page-options.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 
+import type { Page } from 'puppeteer'
+
 import { CleanedMap, defaultPageOptions, getPageOptions, mergePages, PagesFunction } from 'astro-pdf/dist/options.js'
 
 describe('merge pages', () => {
@@ -99,6 +101,6 @@ describe('page options', () => {
         const p = result![0].path
         expect(p).toBeTypeOf('function')
         if (typeof p !== 'function') return
-        expect(p(new URL('http://localhost:4321/route/a'))).toBe('static/route/a.pdf')
+        expect(p(new URL('http://localhost:4321/route/a'), {} as Page)).toBe('static/route/a.pdf')
     })
 })


### PR DESCRIPTION
- allow `path` callback to return a promise
- add `page: Page` param to the callback to allow dyanmic path based on page content
- clarify use of special chars in path in docs
- include cause message in message of `UnexpectedError`
- improve error handling for callbacks to not throw `UnexpectedError`
- include stack trace when logging errors