### PR TITLE
improve warnings for output path

### DIFF
--- a/.changeset/thirty-clouds-cover.md
+++ b/.changeset/thirty-clouds-cover.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+throw an error if the output `path` is a directory (i.e. has a trailing slash)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { open, type FileHandle } from 'node:fs/promises'
 import { extname, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-export async function openFd(path: string, debug: (message: string) => void) {
+export async function openFd(path: string, debug: (message: string) => void, warn: (message: string) => void) {
     const ext = extname(path)
     const name = path.substring(0, path.length - ext.length)
     let i = 0
@@ -17,6 +17,9 @@ export async function openFd(path: string, debug: (message: string) => void) {
         } catch (err) {
             debug('openFd: ' + err)
             i++
+        }
+        if (i === 9) {
+            warn(`failed to open \`${name}-\${i}${ext}\` 10 times. run with --verbose to check the errors from openFd.`)
         }
     }
     return { fd, path: p }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,14 +9,17 @@ export async function openFd(path: string, debug: (message: string) => void, war
     let fd: FileHandle | null = null
     let p: string = path
     while (fd === null) {
+        const suffix = i ? '-' + i : ''
+        p = name + suffix + ext
         try {
-            const suffix = i ? '-' + i : ''
-            p = name + suffix + ext
             fd = await open(p, 'wx')
             break
         } catch (err) {
             debug('openFd: ' + err)
             i++
+            if (!(err instanceof Error && 'code' in err && err.code === 'EEXIST')) {
+                warn(`unexpected error while opening \`${p}\`: ${err}`)
+            }
         }
         if (i === 9) {
             warn(`failed to open \`${name}-\${i}${ext}\` 10 times. run with --verbose to check the errors from openFd.`)

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -33,7 +33,8 @@ describe('process page', () => {
             browser: await launch(),
             baseUrl: new URL('http://localhost:' + address.port),
             outDir: fileURLToPath(new URL('./dist/', root)),
-            debug: () => {}
+            debug: () => {},
+            warn: () => {}
         }
         await Promise.all((await env.browser.pages()).map((page) => page.close()))
         if (existsSync(env.outDir)) {

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -34,7 +34,7 @@ describe('process page', () => {
             baseUrl: new URL('http://localhost:' + address.port),
             outDir: fileURLToPath(new URL('./dist/', root)),
             debug: () => {},
-            warn: () => {}
+            warn: vi.fn(() => {})
         }
         await Promise.all((await env.browser.pages()).map((page) => page.close()))
         if (existsSync(env.outDir)) {
@@ -165,6 +165,7 @@ describe('process page', () => {
         const pathnames = [results[0].output.pathname, results[1].output.pathname]
         expect(pathnames).toContain('/output.pdf')
         expect(pathnames).toContain('/output-1.pdf')
+        expect(env.warn).toBeCalledTimes(0)
     })
 
     test('dynamic page dimensions', async () => {


### PR DESCRIPTION
- throw error if output path is a directory as it leads to unexpected behaviour
- warn if errors other than EEXIST are caught in openFd
- warn if openFd loops 10 times (soft limit)

should help with #80 