### PR TITLE
add `throwErrors` option

### DIFF
--- a/.changeset/tall-waves-fix.md
+++ b/.changeset/tall-waves-fix.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+added `throwErrors` option to prevent `astro-pdf` from causing Astro build fails. Fixed the error handling of custom servers to be consistent with the new option.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ export interface Options
 
     This can also be set to `false` to not run any server. If `server` is set to `false` or returns no URL, then only pages with a full URL specified for the location in [`PagesMap`](#pagesmap) will work.
 
+- **`throwErrors`**: `boolean` _(optional)_
+
+    Set to `false` to prevent `astro-pdf` from throwing any errors. This will cause `astro-pdf` to exit gracefully when it encounters errors, instead of the default behaviour of causing the whole Astro build to fail.
+
 - **`baseOptions`**: [`Partial<PageOptions>`](#pageoptions) _(optional)_
 
     Default options to use for each page. Overrides the default options of [`PageOptions`](#pageoptions).
@@ -218,7 +222,7 @@ Specifies options for generating each PDF. All options are optional when specify
 
     Default: `false`
 
-    Set to throw errors encountered when loading and processing the page. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for the page.
+    Set to throw errors encountered when loading and processing the page. This will cause the build of your site to fail when `astro-pdf` fails to generate the PDF for the page if `throwErrors` is set to `true` in [`Options`](#options) (which is the default).
 
     By default, errors for failed pages will be logged and the build will still successfully complete.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'node:events'
 import { extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -14,8 +15,6 @@ import { astroPreview, type ServerOutput } from './server.js'
 export type { PagesEntry, PagesFunction, PagesMap } from './options.js'
 export type { ServerOutput } from './server.js'
 export type { Options, PageOptions }
-
-const INTERRUPT = Symbol()
 
 export default function pdf(options: Options): AstroIntegration {
     let cacheDir: string
@@ -52,180 +51,194 @@ export default function pdf(options: Options): AstroIntegration {
                 const versionColour = VERSION.includes('-') ? yellow : green
                 logger.info(`\r${bold(bgBlue(' astro-pdf '))} ${versionColour('v' + VERSION)} – generating pdf files`)
 
-                if (typeof options.runBefore === 'function') {
-                    logger.info(dim('running runBefore hook...'))
-                    const runStart = Date.now()
-                    await options.runBefore(dir)
-                    logger.debug(`finished running runBefore hook in ${Date.now() - runStart}ms`)
-                }
-
-                const executablePath = await findOrInstallBrowser(options.install, cacheDir, logger)
-                logger.debug(`using browser at ${blue(executablePath)}`)
-
-                const outDir = fileURLToPath(dir)
-
-                // run astro preview
-                let serverFn = options.server
-                if (serverFn === false) {
-                    logger.debug('running without server')
-                } else if (typeof serverFn !== 'function') {
-                    logger.debug('running astro preview server')
-                    serverFn = astroPreview
-                } else {
-                    logger.debug('running custom server')
-                }
-                let url: URL | undefined = undefined
-                let close: ServerOutput['close'] = undefined
-                if (serverFn) {
-                    try {
-                        const server = await serverFn(astroConfig)
-                        url = server.url
-                        close = server.close
-                    } catch (e) {
-                        logger.error('error when setting up server: ' + e)
-                        return
+                try {
+                    if (typeof options.runBefore === 'function') {
+                        logger.info(dim('running runBefore hook...'))
+                        const runStart = Date.now()
+                        await options.runBefore(dir)
+                        logger.debug(`finished running runBefore hook in ${Date.now() - runStart}ms`)
                     }
-                    if (url) {
-                        logger.info(`using server at ${blue(url.href)}`)
+
+                    const executablePath = await findOrInstallBrowser(options.install, cacheDir, logger)
+                    logger.debug(`using browser at ${blue(executablePath)}`)
+
+                    const outDir = fileURLToPath(dir)
+
+                    // run astro preview
+                    let serverFn = options.server
+                    if (serverFn === false) {
+                        logger.debug('running without server')
+                    } else if (typeof serverFn !== 'function') {
+                        logger.debug('running astro preview server')
+                        serverFn = astroPreview
                     } else {
-                        logger.warn(`no url returned from server. all locations must be full urls.`)
+                        logger.debug('running custom server')
                     }
-                }
-
-                const browser = await launch({
-                    executablePath,
-                    ...options.launch
-                })
-                logger.debug(`launched browser ${await browser.version()}`)
-
-                await Promise.all((await browser.pages()).map((page) => page.close()))
-
-                const { locations, map, fallback } = mergePages(pages, options.pages)
-
-                const queue: { location: string; pageOptions: PageOptions }[] = []
-                locations.forEach((location) => {
-                    const arr = getPageOptions(location, basePageOptions, map, fallback)
-                    queue.push(...arr.map((pageOptions) => ({ location, pageOptions })))
-                })
-
-                const env = {
-                    outDir,
-                    browser,
-                    baseUrl: url,
-                    debug: (message: string) => logger.debug(message),
-                    warn: (message: string) => logger.warn(message)
-                }
-
-                let totalCount = queue.length
-
-                const generated: string[] = []
-
-                async function task(location: string, pageOptions: PageOptions, i: number = 1) {
-                    const maxRuns = Math.max(pageOptions.maxRetries ?? 0, 0) + 1
-                    const start = Date.now()
-                    const retryInfo = maxRuns > 1 ? ` (${i}/${maxRuns} attempts)` : ''
-                    try {
-                        const result = await processPage(location, pageOptions, env)
-                        const pathname = result.output.pathname
-                        generated.push(pathname)
-
-                        const time = Date.now() - start
-                        const src = result.src ? dim(' ← ' + result.src) : ''
-                        const attempts = i > 1 ? dim(retryInfo) : ''
-                        logger.info(`${green('▶')} ${result.location}${src}${attempts}`)
-
-                        const out = extname(pathname) !== '.pdf' ? yellow(pathname) : pathname
-                        logger.info(`  ${blue('└─')} ${dim(`${out} (+${time}ms) (${generated.length}/${totalCount})`)}`)
-                    } catch (err) {
-                        const attempts = maxRuns > 1 && i < maxRuns ? yellow(retryInfo) : retryInfo
-
-                        if (err instanceof PageError) {
-                            if (i < maxRuns || !pageOptions.throwOnFail) {
-                                const time = Date.now() - start
-                                const src = err.src ? dim(' ← ' + err.src) : ''
-                                logger.info(
-                                    red(`✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${attempts}`)
-                                )
-                            }
-                            const causeStack =
-                                err.cause instanceof Error ? `\n${bold('Caused by:')}\n${err.cause.stack}` : ''
-                            logger.debug(bold(red(`error while processing ${location}:\n`)) + err.stack + causeStack)
+                    let url: URL | undefined = undefined
+                    let close: ServerOutput['close'] = undefined
+                    if (serverFn) {
+                        try {
+                            const server = await serverFn(astroConfig)
+                            url = server.url
+                            close = server.close
+                        } catch (e) {
+                            throw new Error('error when setting up server: ' + e)
+                        }
+                        if (url) {
+                            logger.info(`using server at ${blue(url.href)}`)
                         } else {
-                            let error = err
-                            if (!(err instanceof FatalError)) {
+                            logger.warn(`no url returned from server. all locations must be full urls.`)
+                        }
+                    }
+
+                    const browser = await launch({
+                        executablePath,
+                        ...options.launch
+                    })
+                    logger.debug(`launched browser ${await browser.version()}`)
+
+                    const controller = new AbortController()
+
+                    function onDisconnected() {
+                        controller.abort(new FatalError('Fatal error: Browser disconnected unexpectedly'))
+                        console.log('browser disconnected')
+                    }
+                    browser.on('disconnected', onDisconnected)
+
+                    await Promise.all((await browser.pages()).map((page) => page.close()))
+
+                    const { locations, map, fallback } = mergePages(pages, options.pages)
+
+                    const queue: { location: string; pageOptions: PageOptions }[] = []
+                    locations.forEach((location) => {
+                        const arr = getPageOptions(location, basePageOptions, map, fallback)
+                        queue.push(...arr.map((pageOptions) => ({ location, pageOptions })))
+                    })
+
+                    const concurrency = Math.max(options.maxConcurrent ?? Number.POSITIVE_INFINITY, 1)
+
+                    const signal = controller.signal
+                    EventEmitter.setMaxListeners(Math.min(queue.length, concurrency) + 1, signal)
+
+                    const env = {
+                        outDir,
+                        browser,
+                        baseUrl: url,
+                        signal,
+                        debug: (message: string) => logger.debug(message),
+                        warn: (message: string) => logger.warn(message)
+                    }
+
+                    let totalCount = queue.length
+
+                    const generated: string[] = []
+
+                    async function task(location: string, pageOptions: PageOptions, i: number = 1) {
+                        const maxRuns = Math.max(pageOptions.maxRetries ?? 0, 0) + 1
+                        const start = Date.now()
+                        const retryInfo = maxRuns > 1 ? ` (${i}/${maxRuns} attempts)` : ''
+                        try {
+                            const result = await processPage(location, pageOptions, env)
+                            const pathname = result.output.pathname
+                            generated.push(pathname)
+
+                            const time = Date.now() - start
+                            const src = result.src ? dim(' ← ' + result.src) : ''
+                            const attempts = i > 1 ? dim(retryInfo) : ''
+                            logger.info(`${green('▶')} ${result.location}${src}${attempts}`)
+
+                            const out = extname(pathname) !== '.pdf' ? yellow(pathname) : pathname
+                            logger.info(`  ${blue('└─')} ${dim(`${out} (+${time}ms) (${generated.length}/${totalCount})`)}`)
+                        } catch (err) {
+                            const attempts = maxRuns > 1 && i < maxRuns ? yellow(retryInfo) : retryInfo
+
+                            if (err instanceof PageError) {
+                                if (i < maxRuns || !pageOptions.throwOnFail) {
+                                    const time = Date.now() - start
+                                    const src = err.src ? dim(' ← ' + err.src) : ''
+                                    logger.info(
+                                        red(`✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${attempts}`)
+                                    )
+                                }
+                                const causeStack =
+                                    err.cause instanceof Error ? `\n${bold('Caused by:')}\n${err.cause.stack}` : ''
+                                logger.debug(bold(red(`error while processing ${location}:\n`)) + err.stack + causeStack)
+                            } else {
+                                if (err instanceof FatalError) {
+                                    throw err
+                                }
                                 // wrap unexpected errors with a more useful message
-                                error = new Error(
+                                throw new Error(
                                     `An unexpected error occurred and was not handled by astro-pdf while processing \`${location}\`:\n\n` +
                                         err +
                                         '\n\nConsider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose\n',
                                     { cause: err }
                                 )
                             }
-                            if (pageOptions.throwOnFail) {
-                                throw error
+
+                            if (i < maxRuns) {
+                                await task(location, pageOptions, i + 1)
                             } else {
-                                if (error instanceof Error && error.stack) {
-                                    if (error.cause instanceof Error) {
-                                        logger.error(`${error.stack}\n\n${bold('Caused by:')}\n${error.cause.stack}\n`)
-                                    } else {
-                                        logger.error(error.stack + '\n')
-                                    }
-                                } else {
-                                    logger.error(error + '\n')
+                                totalCount--
+                                if (pageOptions.throwOnFail) {
+                                    throw err
                                 }
-                                throw INTERRUPT
-                            }
-                        }
-
-                        if (i < maxRuns) {
-                            await task(location, pageOptions, i + 1)
-                        } else {
-                            totalCount--
-                            if (pageOptions.throwOnFail) {
-                                throw err
                             }
                         }
                     }
-                }
 
-                try {
-                    if (typeof options.browserCallback === 'function') {
-                        await options.browserCallback(browser)
-                    }
-                    await pMap(queue, ({ location, pageOptions }) => task(location, pageOptions), {
-                        concurrency: options.maxConcurrent ?? Number.POSITIVE_INFINITY
-                    })
-                } catch (err) {
-                    if (err === INTERRUPT) {
-                        return
-                    } else {
+                    try {
+                        if (typeof options.browserCallback === 'function') {
+                            await options.browserCallback(browser)
+                        }
+                        await pMap(queue, ({ location, pageOptions }) => task(location, pageOptions), {
+                            concurrency,
+                            signal
+                        })
+                    } catch (err) {
+                        if (!signal.aborted) {
+                            controller.abort(err)
+                        }
                         throw err
+                    } finally {
+                        await browser.off('disconnected', onDisconnected).close()
+                        if (typeof close === 'function') {
+                            await close()
+                        }
+
+                        const noExt = generated.filter((path) => extname(path) !== '.pdf').length
+                        if (noExt > 0) {
+                            logger.warn(`${noExt} file${noExt === 1 ? '' : 's'} generated without .pdf extension`)
+                        }
+        
+                        if (generated.length < queue.length) {
+                            const n = queue.length - generated.length
+                            logger.error(red(`Failed to generate ${n} file${n === 1 ? '' : 's'}`))
+                        }
                     }
-                } finally {
-                    await browser.close()
-                    if (typeof close === 'function') {
-                        await close()
+
+                    if (typeof options.runAfter === 'function') {
+                        logger.info(dim('running runAfter hook...'))
+                        const runStart = Date.now()
+                        await options.runAfter(dir, generated)
+                        logger.debug(`finished running runAfter hook in ${Date.now() - runStart}ms`)
+                    }
+
+                    logger.info(green(`✓ Completed in ${Date.now() - startTime}ms.\n`))
+                } catch (error) {
+                    logger.info(red(`✖︎ Failed after ${Date.now() - startTime}ms.\n`))
+                    if (options.throwErrors ?? true) {
+                        throw error
+                    } else if (error instanceof Error && error.stack) {
+                        if (error.cause instanceof Error) {
+                            logger.error(`${error.stack}\n\n${bold('Caused by:')}\n${error.cause.stack}\n`)
+                        } else {
+                            logger.error(error.stack + '\n')
+                        }
+                    } else {
+                        logger.error(error + '\n')
                     }
                 }
-
-                const noExt = generated.filter((path) => extname(path) !== '.pdf').length
-                if (noExt > 0) {
-                    logger.warn(`${noExt} file${noExt === 1 ? '' : 's'} generated without .pdf extension`)
-                }
-
-                if (generated.length < queue.length) {
-                    const n = queue.length - generated.length
-                    logger.error(red(`Failed to generate ${n} file${n === 1 ? '' : 's'}`))
-                }
-
-                if (typeof options.runAfter === 'function') {
-                    logger.info(dim('running runAfter hook...'))
-                    const runStart = Date.now()
-                    await options.runAfter(dir, generated)
-                    logger.debug(`finished running runAfter hook in ${Date.now() - runStart}ms`)
-                }
-
-                logger.info(green(`✓ Completed in ${Date.now() - startTime}ms.\n`))
             }
         }
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,6 +18,7 @@ export interface Options {
     server?: ((config: AstroConfig) => ServerOutput | Promise<ServerOutput>) | false
     pages: PagesFunction | PagesMap
     maxConcurrent?: number | null
+    throwErrors?: boolean
     runBefore?: (dir: URL) => void | Promise<void>
     runAfter?: (dir: URL, pathnames: string[]) => void | Promise<void>
     browserCallback?: (browser: Browser) => void | Promise<void>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,13 +2,14 @@ import { open, type FileHandle } from 'node:fs/promises'
 import { extname, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-export async function openFd(path: string, debug: (message: string) => void, warn: (message: string) => void) {
+export async function openFd(path: string, debug: (message: string) => void, warn: (message: string) => void, signal?: AbortSignal) {
     const ext = extname(path)
     const name = path.substring(0, path.length - ext.length)
     let i = 0
     let fd: FileHandle | null = null
     let p: string = path
     while (fd === null) {
+        signal?.throwIfAborted()
         const suffix = i ? '-' + i : ''
         p = name + suffix + ext
         try {
@@ -29,16 +30,18 @@ export async function openFd(path: string, debug: (message: string) => void, war
 }
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
-export async function pipeToFd(stream: ReadableStream<Uint8Array>, fd: FileHandle) {
+export async function pipeToFd(stream: ReadableStream<Uint8Array>, fd: FileHandle, signal?: AbortSignal) {
     const writeStream = fd.createWriteStream()
     const reader = stream.getReader()
 
     try {
         while (true) {
+            signal?.throwIfAborted()
             const { value, done } = await reader.read()
             if (done) {
                 break
             }
+            signal?.throwIfAborted()
             writeStream.write(value)
         }
     } finally {

--- a/test/fixtures/concurrent/astro.config.ts
+++ b/test/fixtures/concurrent/astro.config.ts
@@ -19,6 +19,11 @@ const pages: PagesMap = {
                         .trim()
                         .replaceAll(/\s+/g, '-') + '.pdf'
                 )
+            },
+            async callback(page) {
+                if ((await page.title()).toLowerCase().includes('j')) {
+                    await page.browser().close()
+                }
             }
         })),
     'https://fake.example.com': 'fake.pdf'
@@ -29,12 +34,12 @@ export default defineConfig({
         pdf({
             pages,
             baseOptions: {
+                //throwOnFail: true,
                 waitUntil: 'networkidle0'
                 //maxRetries: 2
                 //navTimeout: 0
-                //throwOnFail: true
             },
-            maxConcurrent: null //40
+            maxConcurrent: 5
         })
     ]
 })

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -124,8 +124,12 @@ describe('load page', () => {
             height: 99,
             deviceScaleFactor: 1
         }
-        await loadPage('/index.html', base, page, 'load', viewport, 12345, async (page) => {
-            pass = page.viewport() === viewport && page.getDefaultNavigationTimeout() === 12345
+        await loadPage('/index.html', base, page, 'load', {
+            viewport,
+            navTimeout: 12345,
+            preCallback: async (page) => {
+                pass = page.viewport() === viewport && page.getDefaultNavigationTimeout() === 12345
+            }
         })
         expect(pass).toBe(true)
     })


### PR DESCRIPTION
- added `throwErrors` option (default `true`) which can be set to `false` to stop any errors from being thrown.
- if `false`, errors will interrupt `astro-pdf`'s execution and be logged, but not thrown. this will allow the build to still complete.
- use `AbortSignal` to better cancel running tasks when an error is encountered