### PR TITLE
add `ensurePath` option

### DIFF
--- a/.changeset/curly-falcons-fail.md
+++ b/.changeset/curly-falcons-fail.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+add `ensurePath` page option to throw if there is a filename conflict instead of adding a suffix to the path

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Specifies options for generating each PDF. All options are optional when specify
 
     If there is already a file with the same name, a counter suffix will be added to prevent overwriting the file. For example: `example.pdf` then `example-1.pdf` then `example-2.pdf`.
 
+- **`ensurePath`**: `boolean`
+
+    Default: `false`
+
+    Set to `true` to ensure that the output path of the file is the same as the `path` option. This will prevent `astro-pdf` from adding the counter suffix if there is a file with the same name, and will instead cause the processing of that page to fail.
+
 - **`screen`**: `boolean`
 
     Default: `false`

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,6 +36,7 @@ export type PDFOptions = Omit<PuppeteerPDFOptions, 'path'>
 
 export interface PageOptions {
     path: string | ((url: URL, page: Page) => string | Promise<string>)
+    ensurePath?: boolean
     screen: boolean
     viewport?: Viewport
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[]
@@ -50,6 +51,7 @@ export interface PageOptions {
 
 export const defaultPageOptions = {
     path: '[pathname].pdf',
+    ensurePath: false,
     screen: false,
     waitUntil: 'networkidle2',
     pdf: {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 export async function openFd(
     path: string,
+    ensure: boolean | undefined,
     debug: (message: string) => void,
     warn: (message: string) => void,
     signal?: AbortSignal
@@ -22,6 +23,9 @@ export async function openFd(
             break
         } catch (err) {
             debug('openFd: ' + err)
+            if (ensure) {
+                return { err, fd, path: p }
+            }
             i++
             if (!(err instanceof Error && 'code' in err && err.code === 'EEXIST')) {
                 warn(`unexpected error while opening \`${p}\`: ${err}`)

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -168,6 +168,20 @@ describe('process page', () => {
         expect(env.warn).toBeCalledTimes(0)
     })
 
+    test('throws for conflicting filenames with ensurePath', async () => {
+        const options: PageOptions = {
+            path: 'another-output.pdf',
+            ensurePath: true,
+            screen: false,
+            waitUntil: 'networkidle2',
+            pdf: {}
+        }
+        expect(existsSync(resolve(env.outDir, 'another-output.pdf'))).toBe(false)
+        const promise = Promise.all([processPage('/docs', options, env), processPage('/docs/page', options, env)])
+        await expect(promise).rejects.toThrow('file already exists')
+        expect(existsSync(resolve(env.outDir, 'another-output.pdf'))).toBe(true)
+    })
+
     test('dynamic page dimensions', async () => {
         const PAGE_WIDTH_PX = 1440
         const options: PageOptions = {


### PR DESCRIPTION
added `ensurePath` page option which will throw a `PageError` if set to `true` and `path` already exists.

if `false` then it will be the previous behaviour of adding a counter suffix to `path` until an available filename is found

also helps will issues like #80