### PR TITLE
docs: add page descriptions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@astrojs/check": "^0.9.4",
-        "@lameuler/atlas": "^2.2.0",
+        "@lameuler/atlas": "^2.2.1",
         "astro": "^5.1.8",
         "typescript": "^5.7.3"
     }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@astrojs/check": "^0.9.4",
-        "@lameuler/atlas": "^2.1.2",
+        "@lameuler/atlas": "^2.2.0",
         "astro": "^5.1.8",
         "typescript": "^5.7.3"
     }

--- a/docs/src/content/configuring-puppeteer.md
+++ b/docs/src/content/configuring-puppeteer.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Puppeteer
+description: Setup a Puppeteer configuration file to control which browser it installs and uses. Handle common sandbox related issues with Puppeteer on Linux and Windows.
 ---
 
 When `astro-pdf` is installed, it installs `puppeteer`, which will automatically install a recent version of Chrome. However, you can [configure Puppeteer](https://pptr.dev/guides/configuration) to prevent this.
@@ -41,6 +42,8 @@ You can also set `PUPPETEER_SKIP_DOWNLOAD` environment variable when installing 
 ```sh
 PUPPETEER_SKIP_DOWNLOAD=true npm install
 ```
+
+You can then use the [`install` option](reference/options#install) to control which browser to install when `astro-pdf` runs.
 
 ## Linux AppArmor profile
 

--- a/docs/src/content/generating-many-pdfs.md
+++ b/docs/src/content/generating-many-pdfs.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Many PDFs
+description: Configure astro-pdf to generate as many PDFs as possible. This can involve limiting concurrency, increasing timeouts, and allowing retries when errors occur.
 ---
 
 By default, `astro-pdf` tries to load and process all pages in parallel. This helps to speed up build times, but can lead to issues when you need to generate a large number of PDF files. As Puppeteer cannot handle too many page loads at once, the loading may time out after the default navigation timeout of 30 seconds.

--- a/docs/src/content/index.md
+++ b/docs/src/content/index.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: astro-pdf is an Astro integration to generate PDFs from pages on your site, or any other websites. Find out more about how to install and configure astro-pdf.
 ---
 
 `astro-pdf` is an Astro integration to generate PDFs from pages on your site, or any other websites.

--- a/docs/src/content/loading-images.md
+++ b/docs/src/content/loading-images.md
@@ -1,5 +1,6 @@
 ---
 title: Loading Images
+description: Configure astro-pdf to wait for all images to load, including images with loading='lazy'. This will ensure that all images appear in the generated PDF files.
 ---
 
 ## Wait for images

--- a/docs/src/content/modifying-pdfs.md
+++ b/docs/src/content/modifying-pdfs.md
@@ -1,5 +1,6 @@
 ---
 title: Modifying Generated PDFs
+description: astro-pdf can modify the generated PDFs with the help of other tools. For example, to set the title or other metadata, or to merge multiple PDF files into one.
 ---
 
 ## Edit metadata

--- a/docs/src/content/troubleshooting.md
+++ b/docs/src/content/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Troubleshoot common configuration issues which can cause unexpected results when generating PDFs. Find out how to debug unexpected errors while using astro-pdf.
 ---
 
 ## Missing content or timeouts

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "docs": {
             "dependencies": {
                 "@astrojs/check": "^0.9.4",
-                "@lameuler/atlas": "^2.2.0",
+                "@lameuler/atlas": "^2.2.1",
                 "astro": "^5.1.8",
                 "typescript": "^5.7.3"
             }
@@ -2464,9 +2464,9 @@
             }
         },
         "node_modules/@lameuler/atlas": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@lameuler/atlas/-/atlas-2.2.0.tgz",
-            "integrity": "sha512-HezMah6EKa3BDWqICfpqxMuqYYuYM3cT5QkNgEpNjoEO+ULxXqetjDcnxxdJMIUzwdEMKOiab0qtWAJghOdnTA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@lameuler/atlas/-/atlas-2.2.1.tgz",
+            "integrity": "sha512-OkD+A3MjqWfsUxfoo0eFBGWcvzrcxSOxWUDRpb6NDkwJ4c2tiVi2G0zb6N9e6h69UVcH+tQkWasAmYKs3Y2Mqw==",
             "license": "MIT",
             "workspaces": [
                 ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "docs": {
             "dependencies": {
                 "@astrojs/check": "^0.9.4",
-                "@lameuler/atlas": "^2.1.2",
+                "@lameuler/atlas": "^2.2.0",
                 "astro": "^5.1.8",
                 "typescript": "^5.7.3"
             }
@@ -2464,9 +2464,9 @@
             }
         },
         "node_modules/@lameuler/atlas": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@lameuler/atlas/-/atlas-2.1.2.tgz",
-            "integrity": "sha512-vqeK9AIhc214mkgCQ1QeUJ/Rkb9jYZoQgDsh7jm+z8UDNhvi1t+rryAu/eFPdEmDKS8h2elyz5CmxDXYHvO8Rw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@lameuler/atlas/-/atlas-2.2.0.tgz",
+            "integrity": "sha512-HezMah6EKa3BDWqICfpqxMuqYYuYM3cT5QkNgEpNjoEO+ULxXqetjDcnxxdJMIUzwdEMKOiab0qtWAJghOdnTA==",
             "license": "MIT",
             "workspaces": [
                 ".",


### PR DESCRIPTION
docs changes:
- ensure Astro site is https. the github pages provided url is http.
- add descriptions for all pages