### PR TITLE
Upgrade to Astro v6

### DIFF
--- a/.changeset/hip-insects-taste.md
+++ b/.changeset/hip-insects-taste.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+Add support for Astro v6.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    node-version: 20
+    node-version: 22
 
 jobs:
     lint:
@@ -91,12 +91,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [22]
-                include:
-                    - os: ubuntu-latest
-                      node-version: 18
-                    - os: ubuntu-latest
-                      node-version: 20
+                node-version: [22, 24]
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
             - name: Install Dependencies
               run: npm install
 
+            - name: Install docs dependencies
+              run: npm install
+              working-directory: docs
+
             - name: Build docs
               run: npm run build
               working-directory: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,14 @@ jobs:
             - name: Install Dependencies
               run: npm install
 
+            - name: Install docs dependencies
+              run: npm install
+              working-directory: docs
+
             - name: Lint
-              run: npm run lint
+              run: |
+                  npm run lint
+                  npm run lint:docs
 
     format:
         name: 'Check format'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: 'npm'
 
             - name: Install dependencies
@@ -73,7 +73,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: 'npm'
 
             - name: Setup Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,6 +106,10 @@ jobs:
             - name: Install Dependencies
               run: npm ci
 
+            - name: Install docs dependencies
+              run: npm install
+              working-directory: ${{ env.BUILD_PATH }}
+
             - name: Build docs
               run: |
                   npm run build -- \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: 'npm'
 
             - name: Configure AppArmor profile for Puppeteer

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "workspaces": [
                 "./",
-                "./docs",
                 "./test/fixtures/**"
             ],
             "dependencies": {
@@ -29,7 +28,7 @@
                 "@types/eslint-config-prettier": "^6.11.3",
                 "@types/node": "^22.10.1",
                 "@vitest/coverage-istanbul": "^3.0.3",
-                "astro": "^5.0.3",
+                "astro": "^6.0.4",
                 "cheerio": "^1.0.0",
                 "eslint": "^9.16.0",
                 "eslint-config-prettier": "^9.1.0",
@@ -46,10 +45,11 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "astro": "^4.4.4 || ^5.0.0"
+                "astro": "^4.4.4 || ^5.0.0 || ^6.0.0"
             }
         },
         "docs": {
+            "extraneous": true,
             "dependencies": {
                 "@astrojs/check": "^0.9.4",
                 "@lameuler/atlas": "^2.2.2",
@@ -61,6 +61,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -71,59 +72,53 @@
             }
         },
         "node_modules/@astrojs/check": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.4.tgz",
-            "integrity": "sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==",
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.7.tgz",
+            "integrity": "sha512-dA7U5/OFg8/xaMUb2vUOOJuuJXnMpHy6F0BM8ZhL7WT5OkTBwJ0GoW38n4fC4CXt+lT9mLWL0y8Pa74tFByBpQ==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/language-server": "^2.15.0",
-                "chokidar": "^4.0.1",
+                "@astrojs/language-server": "^2.16.1",
+                "chokidar": "^4.0.3",
                 "kleur": "^4.1.5",
                 "yargs": "^17.7.2"
             },
             "bin": {
-                "astro-check": "dist/bin.js"
+                "astro-check": "bin/astro-check.js"
             },
             "peerDependencies": {
                 "typescript": "^5.0.0"
             }
         },
         "node_modules/@astrojs/compiler": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
-            "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==",
-            "license": "MIT"
-        },
-        "node_modules/@astrojs/internal-helpers": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.6.1.tgz",
-            "integrity": "sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+            "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
             "license": "MIT"
         },
         "node_modules/@astrojs/language-server": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.4.tgz",
-            "integrity": "sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==",
+            "version": "2.16.4",
+            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.4.tgz",
+            "integrity": "sha512-42oqz9uX+hU1/rFniJvtYW9FbfZJ6syM2fYZFi7Ub71/kOvF1GSeMS8sA3Ogs3iOeNUWefk/ImwBiiHeNmJfSA==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^2.10.3",
-                "@astrojs/yaml2ts": "^0.2.2",
-                "@jridgewell/sourcemap-codec": "^1.4.15",
-                "@volar/kit": "~2.4.7",
-                "@volar/language-core": "~2.4.7",
-                "@volar/language-server": "~2.4.7",
-                "@volar/language-service": "~2.4.7",
-                "fast-glob": "^3.2.12",
+                "@astrojs/compiler": "^2.13.1",
+                "@astrojs/yaml2ts": "^0.2.3",
+                "@jridgewell/sourcemap-codec": "^1.5.5",
+                "@volar/kit": "~2.4.28",
+                "@volar/language-core": "~2.4.28",
+                "@volar/language-server": "~2.4.28",
+                "@volar/language-service": "~2.4.28",
                 "muggle-string": "^0.4.1",
-                "volar-service-css": "0.0.62",
-                "volar-service-emmet": "0.0.62",
-                "volar-service-html": "0.0.62",
-                "volar-service-prettier": "0.0.62",
-                "volar-service-typescript": "0.0.62",
-                "volar-service-typescript-twoslash-queries": "0.0.62",
-                "volar-service-yaml": "0.0.62",
-                "vscode-html-languageservice": "^5.2.0",
-                "vscode-uri": "^3.0.8"
+                "tinyglobby": "^0.2.15",
+                "volar-service-css": "0.0.68",
+                "volar-service-emmet": "0.0.68",
+                "volar-service-html": "0.0.68",
+                "volar-service-prettier": "0.0.68",
+                "volar-service-typescript": "0.0.68",
+                "volar-service-typescript-twoslash-queries": "0.0.68",
+                "volar-service-yaml": "0.0.68",
+                "vscode-html-languageservice": "^5.6.1",
+                "vscode-uri": "^3.1.0"
             },
             "bin": {
                 "astro-ls": "bin/nodeServer.js"
@@ -139,201 +134,6 @@
                 "prettier-plugin-astro": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@astrojs/markdown-remark": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.2.tgz",
-            "integrity": "sha512-bO35JbWpVvyKRl7cmSJD822e8YA8ThR/YbUsciWNA7yTcqpIAL2hJDToWP5KcZBWxGT6IOdOkHSXARSNZc4l/Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@astrojs/internal-helpers": "0.6.1",
-                "@astrojs/prism": "3.3.0",
-                "github-slugger": "^2.0.0",
-                "hast-util-from-html": "^2.0.3",
-                "hast-util-to-text": "^4.0.2",
-                "import-meta-resolve": "^4.1.0",
-                "js-yaml": "^4.1.0",
-                "mdast-util-definitions": "^6.0.0",
-                "rehype-raw": "^7.0.0",
-                "rehype-stringify": "^10.0.1",
-                "remark-gfm": "^4.0.1",
-                "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.1.2",
-                "remark-smartypants": "^3.0.2",
-                "shiki": "^3.2.1",
-                "smol-toml": "^1.3.1",
-                "unified": "^11.0.5",
-                "unist-util-remove-position": "^5.0.0",
-                "unist-util-visit": "^5.0.0",
-                "unist-util-visit-parents": "^6.0.1",
-                "vfile": "^6.0.3"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-9By7Xb3olEX0o6UeJyPLI1PE1scC4d3wcVepvtv2xbuN9/IThYN4Wcwh24rcFeASzPam11MCq8yQpwwzCgSBRw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "3.6.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.5"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-javascript": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.6.0.tgz",
-            "integrity": "sha512-7YnLhZG/TU05IHMG14QaLvTW/9WiK8SEYafceccHUSXs2Qr5vJibUwsDfXDLmRi0zHdzsxrGKpSX6hnqe0k8nA==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "3.6.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "oniguruma-to-es": "^4.3.3"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.6.0.tgz",
-            "integrity": "sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "3.6.0",
-                "@shikijs/vscode-textmate": "^10.0.2"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/langs": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.6.0.tgz",
-            "integrity": "sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "3.6.0"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/themes": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.6.0.tgz",
-            "integrity": "sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "3.6.0"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/oniguruma-to-es": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
-            "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
-            "license": "MIT",
-            "dependencies": {
-                "oniguruma-parser": "^0.12.1",
-                "regex": "^6.0.1",
-                "regex-recursion": "^6.0.2"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
-            "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
-            "license": "MIT",
-            "dependencies": {
-                "regex-utilities": "^2.3.0"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/regex-recursion": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-            "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-            "license": "MIT",
-            "dependencies": {
-                "regex-utilities": "^2.3.0"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/shiki": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.6.0.tgz",
-            "integrity": "sha512-tKn/Y0MGBTffQoklaATXmTqDU02zx8NYBGQ+F6gy87/YjKbizcLd+Cybh/0ZtOBX9r1NEnAy/GTRDKtOsc1L9w==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/core": "3.6.0",
-                "@shikijs/engine-javascript": "3.6.0",
-                "@shikijs/engine-oniguruma": "3.6.0",
-                "@shikijs/langs": "3.6.0",
-                "@shikijs/themes": "3.6.0",
-                "@shikijs/types": "3.6.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
-        "node_modules/@astrojs/prism": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-            "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "prismjs": "^1.30.0"
-            },
-            "engines": {
-                "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-            }
-        },
-        "node_modules/@astrojs/sitemap": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
-            "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
-            "license": "MIT",
-            "dependencies": {
-                "sitemap": "^8.0.0",
-                "stream-replace-string": "^2.0.0",
-                "zod": "^3.23.8"
-            }
-        },
-        "node_modules/@astrojs/svelte": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/svelte/-/svelte-7.0.4.tgz",
-            "integrity": "sha512-vTFhHhYNr1GkrpR63Talv8ba1HHUWoHNzBs4eJNZz4bQCihAdxw+xz/CWcWM1bfAzH3Jfc7jAKXPNAZSwN4oFg==",
-            "license": "MIT",
-            "dependencies": {
-                "@sveltejs/vite-plugin-svelte": "^5.0.3",
-                "svelte2tsx": "^0.7.34",
-                "vite": "^6.0.9"
-            },
-            "engines": {
-                "node": "^18.17.1 || ^20.3.0 || >=22.0.0"
-            },
-            "peerDependencies": {
-                "astro": "^5.0.0",
-                "svelte": "^5.1.16",
-                "typescript": "^5.3.3"
             }
         },
         "node_modules/@astrojs/telemetry": {
@@ -370,12 +170,12 @@
             }
         },
         "node_modules/@astrojs/yaml2ts": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.2.tgz",
-            "integrity": "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+            "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
             "license": "MIT",
             "dependencies": {
-                "yaml": "^2.5.0"
+                "yaml": "^2.8.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -846,18 +646,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -902,12 +702,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -917,13 +717,13 @@
             }
         },
         "node_modules/@babel/parser/node_modules/@babel/types": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1062,14 +862,15 @@
             }
         },
         "node_modules/@capsizecss/unpack": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-2.4.0.tgz",
-            "integrity": "sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+            "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
             "license": "MIT",
             "dependencies": {
-                "blob-to-buffer": "^1.2.8",
-                "cross-fetch": "^3.0.4",
-                "fontkit": "^2.0.2"
+                "fontkitten": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@changesets/apply-release-plan": {
@@ -1370,6 +1171,25 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/@clack/core": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+            "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+            "license": "MIT",
+            "dependencies": {
+                "sisteransi": "^1.0.5"
+            }
+        },
+        "node_modules/@clack/prompts": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+            "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+            "license": "MIT",
+            "dependencies": {
+                "@clack/core": "1.1.0",
+                "sisteransi": "^1.0.5"
+            }
+        },
         "node_modules/@emmetio/abbreviation": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
@@ -1389,9 +1209,9 @@
             }
         },
         "node_modules/@emmetio/css-parser": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
-            "integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+            "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
             "license": "MIT",
             "dependencies": {
                 "@emmetio/stream-reader": "^2.2.0",
@@ -1426,9 +1246,9 @@
             "license": "MIT"
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-            "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1442,6 +1262,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1458,6 +1279,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1474,6 +1296,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1490,6 +1313,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1506,6 +1330,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1522,6 +1347,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1538,6 +1364,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1554,6 +1381,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1570,6 +1398,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1586,6 +1415,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1602,6 +1432,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1618,6 +1449,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1634,6 +1466,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1650,6 +1483,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1666,6 +1500,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1682,6 +1517,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1698,6 +1534,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1714,6 +1551,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1730,6 +1568,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1746,6 +1585,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1762,10 +1602,27 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+            "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
             ],
             "engines": {
                 "node": ">=18"
@@ -1778,6 +1635,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1794,6 +1652,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1810,6 +1669,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1826,6 +1686,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1996,17 +1857,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@gerrit0/mini-shiki": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-            "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/engine-oniguruma": "^1.27.2",
-                "@shikijs/types": "^1.27.2",
-                "@shikijs/vscode-textmate": "^10.0.1"
-            }
-        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2073,10 +1923,20 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
             "cpu": [
                 "arm64"
             ],
@@ -2092,13 +1952,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.0.4"
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-            "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
             "cpu": [
                 "x64"
             ],
@@ -2114,13 +1974,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.0.4"
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
             "cpu": [
                 "arm64"
             ],
@@ -2134,9 +1994,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-            "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
             "cpu": [
                 "x64"
             ],
@@ -2150,9 +2010,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-            "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
             "cpu": [
                 "arm"
             ],
@@ -2166,9 +2026,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-            "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
             ],
@@ -2181,10 +2041,42 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-            "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2198,9 +2090,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-            "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
             ],
@@ -2214,9 +2106,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-            "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
             "cpu": [
                 "arm64"
             ],
@@ -2230,9 +2122,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-            "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
             "cpu": [
                 "x64"
             ],
@@ -2246,9 +2138,9 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-            "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
             ],
@@ -2264,13 +2156,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.0.5"
+                "@img/sharp-libvips-linux-arm": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-            "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
             "cpu": [
                 "arm64"
             ],
@@ -2286,13 +2178,57 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.0.4"
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-            "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
             ],
@@ -2308,13 +2244,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.0.4"
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-            "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
             "cpu": [
                 "x64"
             ],
@@ -2330,13 +2266,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.0.4"
+                "@img/sharp-libvips-linux-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-            "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
             "cpu": [
                 "arm64"
             ],
@@ -2352,13 +2288,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-            "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
             ],
@@ -2374,20 +2310,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-            "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
             "cpu": [
                 "wasm32"
             ],
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.2.0"
+                "@emnapi/runtime": "^1.7.0"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2396,10 +2332,29 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-            "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
             "cpu": [
                 "ia32"
             ],
@@ -2416,9 +2371,9 @@
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-            "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
             "cpu": [
                 "x64"
             ],
@@ -2538,6 +2493,7 @@
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
             "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
@@ -2552,6 +2508,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -2561,76 +2518,27 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
             "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@lameuler/atlas": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@lameuler/atlas/-/atlas-2.2.2.tgz",
-            "integrity": "sha512-4n/h90WVUG3Y3EWUjGUihwXSogW5U26sxZFXhzmjKkbPtDatbT7AplBTRbP0948fbvqi/TsBT9S1j85jTsfhxw==",
-            "license": "MIT",
-            "workspaces": [
-                ".",
-                "demo",
-                "temp/*"
-            ],
-            "dependencies": {
-                "@astrojs/markdown-remark": "^6.0.1",
-                "@astrojs/sitemap": "^3.2.1",
-                "@astrojs/svelte": "^7.0.2",
-                "@lameuler/ler-astro": "^2.5.1",
-                "@rollup/plugin-virtual": "^3.0.2",
-                "@shikijs/transformers": "^2.1.0",
-                "github-slugger": "^2.0.0",
-                "hastscript": "^9.0.0",
-                "pagefind": "^1.3.0",
-                "puppeteer": "^23.11.1",
-                "rehype-autolink-headings": "^7.1.0",
-                "rehype-sanitize": "^6.0.0",
-                "rehype-stringify": "^10.0.1",
-                "remark-gfm": "^4.0.0",
-                "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.1.1",
-                "remark-smartypants": "^3.0.2",
-                "shiki": "^1.27.2",
-                "svelte": "^5.16.0",
-                "typedoc": "~0.27.6",
-                "unist-util-visit": "^5.0.0",
-                "zod": "^3.24.1"
-            },
-            "peerDependencies": {
-                "astro": "^5.0.0"
-            }
-        },
-        "node_modules/@lameuler/ler-astro": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@lameuler/ler-astro/-/ler-astro-2.5.1.tgz",
-            "integrity": "sha512-YfGTJZiD8z/MAeIV0SiLQF0wHcSHB9OR+7rTAGLAjtUh9ds15lwCEDS/RvBFPthpEZIOHzXjHvEqvWqGFzeNoQ==",
-            "license": "MIT",
-            "workspaces": [
-                ".",
-                "test"
-            ],
-            "peerDependencies": {
-                "astro": "^4.0.0 || ^5.0.0"
             }
         },
         "node_modules/@manypkg/find-root": {
@@ -2709,6 +2617,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -2722,6 +2631,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -2731,6 +2641,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -2745,71 +2656,6 @@
             "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
             "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
             "license": "MIT"
-        },
-        "node_modules/@pagefind/darwin-arm64": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
-            "integrity": "sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@pagefind/darwin-x64": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz",
-            "integrity": "sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@pagefind/linux-arm64": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz",
-            "integrity": "sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@pagefind/linux-x64": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz",
-            "integrity": "sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@pagefind/windows-x64": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz",
-            "integrity": "sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
         },
         "node_modules/@pdf-lib/standard-fonts": {
             "version": "1.0.0",
@@ -2862,27 +2708,10 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@rollup/plugin-virtual": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
-            "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-            "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -3167,122 +2996,31 @@
                 "win32"
             ]
         },
-        "node_modules/@shikijs/core": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.1.tgz",
-            "integrity": "sha512-Mo1gGGkuOYjDu5H8YwzmOuly9vNr8KDVkqj9xiKhhhFS8jisAtDSEWB9hzqRHLVQgFdA310e8XRJcW4tYhRB2A==",
+        "node_modules/@shikijs/primitive": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+            "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-javascript": "1.29.1",
-                "@shikijs/engine-oniguruma": "1.29.1",
-                "@shikijs/types": "1.29.1",
-                "@shikijs/vscode-textmate": "^10.0.1",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.4"
-            }
-        },
-        "node_modules/@shikijs/engine-javascript": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.1.tgz",
-            "integrity": "sha512-Hpi8k9x77rCQ7F/7zxIOUruNkNidMyBnP5qAGbLFqg4kRrg1HZhkB8btib5EXbQWTtLb5gBHOdBwshk20njD7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "1.29.1",
-                "@shikijs/vscode-textmate": "^10.0.1",
-                "oniguruma-to-es": "^2.2.0"
-            }
-        },
-        "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.1.tgz",
-            "integrity": "sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "1.29.1",
-                "@shikijs/vscode-textmate": "^10.0.1"
-            }
-        },
-        "node_modules/@shikijs/langs": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.1.tgz",
-            "integrity": "sha512-iERn4HlyuT044/FgrvLOaZgKVKf3PozjKjyV/RZ5GnlyYEAZFcgwHGkYboeBv2IybQG1KVS/e7VGgiAU4JY2Gw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "1.29.1"
-            }
-        },
-        "node_modules/@shikijs/themes": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.1.tgz",
-            "integrity": "sha512-lb11zf72Vc9uxkl+aec2oW1HVTHJ2LtgZgumb4Rr6By3y/96VmlU44bkxEb8WBWH3RUtbqAJEN0jljD9cF7H7g==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "1.29.1"
-            }
-        },
-        "node_modules/@shikijs/transformers": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.1.0.tgz",
-            "integrity": "sha512-3sfvh6OKUVkT5wZFU1xxiq1qqNIuCwUY3yOb9ZGm19y80UZ/eoroLE2orGNzfivyTxR93GfXXZC/ghPR0/SBow==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/core": "2.1.0",
-                "@shikijs/types": "2.1.0"
-            }
-        },
-        "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.1.0.tgz",
-            "integrity": "sha512-v795KDmvs+4oV0XD05YLzfDMe9ISBgNjtFxP4PAEv5DqyeghO1/TwDqs9ca5/E6fuO95IcAcWqR6cCX9TnqLZA==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/engine-javascript": "2.1.0",
-                "@shikijs/engine-oniguruma": "2.1.0",
-                "@shikijs/types": "2.1.0",
-                "@shikijs/vscode-textmate": "^10.0.1",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.4"
-            }
-        },
-        "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-javascript": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.1.0.tgz",
-            "integrity": "sha512-cgIUdAliOsoaa0rJz/z+jvhrpRd+fVAoixVFEVxUq5FA+tHgBZAIfVJSgJNVRj2hs/wZ1+4hMe82eKAThVh0nQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "2.1.0",
-                "@shikijs/vscode-textmate": "^10.0.1",
-                "oniguruma-to-es": "^2.3.0"
-            }
-        },
-        "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-oniguruma": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.1.0.tgz",
-            "integrity": "sha512-Ujik33wEDqgqY2WpjRDUBECGcKPv3eGGkoXPujIXvokLaRmGky8NisSk8lHUGeSFxo/Cz5sgFej9sJmA9yeepg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "2.1.0",
-                "@shikijs/vscode-textmate": "^10.0.1"
-            }
-        },
-        "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.1.0.tgz",
-            "integrity": "sha512-OFOdHA6VEVbiQvepJ8yqicC6VmBrKxFFhM2EsHHrZESqLVAXOSeRDiuSYV185lIgp15TVic5vYBYNhTsk1xHLg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.1",
+                "@shikijs/types": "4.0.2",
+                "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
-        "node_modules/@shikijs/types": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.1.tgz",
-            "integrity": "sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==",
+        "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.1",
+                "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@shikijs/vscode-textmate": {
@@ -3290,53 +3028,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
             "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
             "license": "MIT"
-        },
-        "node_modules/@sveltejs/vite-plugin-svelte": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.0.3.tgz",
-            "integrity": "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==",
-            "license": "MIT",
-            "dependencies": {
-                "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
-                "debug": "^4.4.0",
-                "deepmerge": "^4.3.1",
-                "kleur": "^4.1.5",
-                "magic-string": "^0.30.15",
-                "vitefu": "^1.0.4"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22"
-            },
-            "peerDependencies": {
-                "svelte": "^5.0.0",
-                "vite": "^6.0.0"
-            }
-        },
-        "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
-            "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.7"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22"
-            },
-            "peerDependencies": {
-                "@sveltejs/vite-plugin-svelte": "^5.0.0",
-                "svelte": "^5.0.0",
-                "vite": "^6.0.0"
-            }
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-            "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
         },
         "node_modules/@test/build-pdf": {
             "resolved": "test/fixtures/build-pdf",
@@ -3423,15 +3114,6 @@
             "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
             "license": "MIT"
         },
-        "node_modules/@types/fontkit": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
-            "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/hast": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -3476,18 +3158,10 @@
             "version": "22.10.8",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.8.tgz",
             "integrity": "sha512-rk+QvAEGsbX/ZPiiyel6hJHNUS9cnSbPWVaZLvE+Er3tLqQFzWMz9JOfWW7XUmKvRPfxJfbl3qYWve+RGXncFw==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
-            }
-        },
-        "node_modules/@types/sax": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
-            "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/unist": {
@@ -3857,13 +3531,13 @@
             }
         },
         "node_modules/@volar/kit": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.11.tgz",
-            "integrity": "sha512-ups5RKbMzMCr6RKafcCqDRnJhJDNWqo2vfekwOAj6psZ15v5TlcQFQAyokQJ3wZxVkzxrQM+TqTRDENfQEXpmA==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+            "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
             "license": "MIT",
             "dependencies": {
-                "@volar/language-service": "2.4.11",
-                "@volar/typescript": "2.4.11",
+                "@volar/language-service": "2.4.28",
+                "@volar/typescript": "2.4.28",
                 "typesafe-path": "^0.2.2",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-uri": "^3.0.8"
@@ -3873,23 +3547,23 @@
             }
         },
         "node_modules/@volar/language-core": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
-            "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
             "license": "MIT",
             "dependencies": {
-                "@volar/source-map": "2.4.11"
+                "@volar/source-map": "2.4.28"
             }
         },
         "node_modules/@volar/language-server": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.11.tgz",
-            "integrity": "sha512-W9P8glH1M8LGREJ7yHRCANI5vOvTrRO15EMLdmh5WNF9sZYSEbQxiHKckZhvGIkbeR1WAlTl3ORTrJXUghjk7g==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+            "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.11",
-                "@volar/language-service": "2.4.11",
-                "@volar/typescript": "2.4.11",
+                "@volar/language-core": "2.4.28",
+                "@volar/language-service": "2.4.28",
+                "@volar/typescript": "2.4.28",
                 "path-browserify": "^1.0.1",
                 "request-light": "^0.7.0",
                 "vscode-languageserver": "^9.0.1",
@@ -3899,30 +3573,30 @@
             }
         },
         "node_modules/@volar/language-service": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.11.tgz",
-            "integrity": "sha512-KIb6g8gjUkS2LzAJ9bJCLIjfsJjeRtmXlu7b2pDFGD3fNqdbC53cCAKzgWDs64xtQVKYBU13DLWbtSNFtGuMLQ==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+            "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.11",
+                "@volar/language-core": "2.4.28",
                 "vscode-languageserver-protocol": "^3.17.5",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-uri": "^3.0.8"
             }
         },
         "node_modules/@volar/source-map": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
-            "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
-            "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.11",
+                "@volar/language-core": "2.4.28",
                 "path-browserify": "^1.0.1",
                 "vscode-uri": "^3.0.8"
             }
@@ -3950,6 +3624,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3966,15 +3641,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/acorn-typescript": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
-            "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": ">=8.9.0"
             }
         },
         "node_modules/agent-base": {
@@ -4003,35 +3669,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ansi-align": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.1.0"
-            }
-        },
-        "node_modules/ansi-align/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
-        },
-        "node_modules/ansi-align/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -4055,6 +3692,7 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -4094,12 +3732,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
-        },
-        "node_modules/arg": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -4163,78 +3795,72 @@
             }
         },
         "node_modules/astro": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.2.tgz",
-            "integrity": "sha512-K/zZlQOWMpamfLDOls5jvG7lrsjH1gkk3ESRZyZDCkVBtKHMF4LbjwCicm/iBb3mX3V/PerqRYzLbOy3/4JLCQ==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.4.tgz",
+            "integrity": "sha512-1piLJCPTL/x7AMO2cjVFSTFyRqKuC3W8sSEySCt1aJio+p/wGs5H3K+Xr/rE9ftKtknLUtjxCqCE7/0NsXfGpQ==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^2.12.2",
-                "@astrojs/internal-helpers": "0.6.1",
-                "@astrojs/markdown-remark": "6.3.2",
+                "@astrojs/compiler": "^3.0.0",
+                "@astrojs/internal-helpers": "0.8.0",
+                "@astrojs/markdown-remark": "7.0.0",
                 "@astrojs/telemetry": "3.3.0",
-                "@capsizecss/unpack": "^2.4.0",
+                "@capsizecss/unpack": "^4.0.0",
+                "@clack/prompts": "^1.0.1",
                 "@oslojs/encoding": "^1.1.0",
-                "@rollup/pluginutils": "^5.1.4",
-                "acorn": "^8.14.1",
+                "@rollup/pluginutils": "^5.3.0",
                 "aria-query": "^5.3.2",
                 "axobject-query": "^4.1.0",
-                "boxen": "8.0.1",
-                "ci-info": "^4.2.0",
+                "ci-info": "^4.4.0",
                 "clsx": "^2.1.1",
-                "common-ancestor-path": "^1.0.1",
-                "cookie": "^1.0.2",
-                "cssesc": "^3.0.0",
-                "debug": "^4.4.0",
-                "deterministic-object-hash": "^2.0.2",
-                "devalue": "^5.1.1",
-                "diff": "^5.2.0",
+                "common-ancestor-path": "^2.0.0",
+                "cookie": "^1.1.1",
+                "devalue": "^5.6.3",
+                "diff": "^8.0.3",
                 "dlv": "^1.1.3",
                 "dset": "^3.1.4",
-                "es-module-lexer": "^1.6.0",
-                "esbuild": "^0.25.0",
-                "estree-walker": "^3.0.3",
+                "es-module-lexer": "^2.0.0",
+                "esbuild": "^0.27.3",
                 "flattie": "^1.1.1",
-                "fontace": "~0.3.0",
+                "fontace": "~0.4.1",
                 "github-slugger": "^2.0.0",
                 "html-escaper": "3.0.3",
-                "http-cache-semantics": "^4.1.1",
-                "import-meta-resolve": "^4.1.0",
-                "js-yaml": "^4.1.0",
-                "kleur": "^4.1.5",
-                "magic-string": "^0.30.17",
-                "magicast": "^0.3.5",
+                "http-cache-semantics": "^4.2.0",
+                "js-yaml": "^4.1.1",
+                "magic-string": "^0.30.21",
+                "magicast": "^0.5.2",
                 "mrmime": "^2.0.1",
                 "neotraverse": "^0.6.18",
-                "p-limit": "^6.2.0",
-                "p-queue": "^8.1.0",
-                "package-manager-detector": "^1.1.0",
-                "picomatch": "^4.0.2",
-                "prompts": "^2.4.2",
+                "obug": "^2.1.1",
+                "p-limit": "^7.3.0",
+                "p-queue": "^9.1.0",
+                "package-manager-detector": "^1.6.0",
+                "piccolore": "^0.1.3",
+                "picomatch": "^4.0.3",
                 "rehype": "^13.0.2",
-                "semver": "^7.7.1",
-                "shiki": "^3.2.1",
-                "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.12",
-                "tsconfck": "^3.1.5",
+                "semver": "^7.7.4",
+                "shiki": "^4.0.0",
+                "smol-toml": "^1.6.0",
+                "svgo": "^4.0.0",
+                "tinyclip": "^0.1.6",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tsconfck": "^3.1.6",
                 "ultrahtml": "^1.6.0",
-                "unifont": "~0.5.0",
-                "unist-util-visit": "^5.0.0",
-                "unstorage": "^1.15.0",
+                "unifont": "~0.7.4",
+                "unist-util-visit": "^5.1.0",
+                "unstorage": "^1.17.4",
                 "vfile": "^6.0.3",
-                "vite": "^6.3.4",
-                "vitefu": "^1.0.6",
+                "vite": "^7.3.1",
+                "vitefu": "^1.1.2",
                 "xxhash-wasm": "^1.1.0",
-                "yargs-parser": "^21.1.1",
-                "yocto-spinner": "^0.2.1",
-                "zod": "^3.24.2",
-                "zod-to-json-schema": "^3.24.5",
-                "zod-to-ts": "^1.2.0"
+                "yargs-parser": "^22.0.0",
+                "zod": "^4.3.6"
             },
             "bin": {
-                "astro": "astro.js"
+                "astro": "bin/astro.mjs"
             },
             "engines": {
-                "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+                "node": "^20.19.1 || >=22.12.0",
                 "npm": ">=9.6.5",
                 "pnpm": ">=7.1.0"
             },
@@ -4243,72 +3869,559 @@
                 "url": "https://opencollective.com/astrodotbuild"
             },
             "optionalDependencies": {
-                "sharp": "^0.33.3"
+                "sharp": "^0.34.0"
             }
         },
         "node_modules/astro-pdf": {
             "resolved": "",
             "link": true
         },
-        "node_modules/astro/node_modules/@shikijs/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-9By7Xb3olEX0o6UeJyPLI1PE1scC4d3wcVepvtv2xbuN9/IThYN4Wcwh24rcFeASzPam11MCq8yQpwwzCgSBRw==",
+        "node_modules/astro/node_modules/@astrojs/compiler": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.0.tgz",
+            "integrity": "sha512-MwAbDE5mawZ1SS+D8qWiHdprdME5Tlj2e0YjxnEICvcOpbSukNS7Sa7hA5PK+6RrmUr/t6Gi5YgrdZKjbO/WPQ==",
+            "license": "MIT"
+        },
+        "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
+            "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.6.0",
+                "picomatch": "^4.0.3"
+            }
+        },
+        "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.0.0.tgz",
+            "integrity": "sha512-jTAXHPy45L7o1ljH4jYV+ShtOHtyQUa1mGp3a5fJp1soX8lInuTJQ6ihmldHzVM4Q7QptU4SzIDIcKbBJO7sXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@astrojs/internal-helpers": "0.8.0",
+                "@astrojs/prism": "4.0.0",
+                "github-slugger": "^2.0.0",
+                "hast-util-from-html": "^2.0.3",
+                "hast-util-to-text": "^4.0.2",
+                "js-yaml": "^4.1.1",
+                "mdast-util-definitions": "^6.0.0",
+                "rehype-raw": "^7.0.0",
+                "rehype-stringify": "^10.0.1",
+                "remark-gfm": "^4.0.1",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.2",
+                "remark-smartypants": "^3.0.2",
+                "shiki": "^4.0.0",
+                "smol-toml": "^1.6.0",
+                "unified": "^11.0.5",
+                "unist-util-remove-position": "^5.0.0",
+                "unist-util-visit": "^5.1.0",
+                "unist-util-visit-parents": "^6.0.2",
+                "vfile": "^6.0.3"
+            }
+        },
+        "node_modules/astro/node_modules/@astrojs/prism": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.0.tgz",
+            "integrity": "sha512-NndtNPpxaGinRpRytljGBvYHpTOwHycSZ/c+lQi5cHvkqqrHKWdkPEhImlODBNmbuB+vyQUNUDXyjzt66CihJg==",
+            "license": "MIT",
+            "dependencies": {
+                "prismjs": "^1.30.0"
+            },
+            "engines": {
+                "node": "^20.19.1 || >=22.12.0"
+            }
+        },
+        "node_modules/astro/node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+            "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-arm": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+            "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+            "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+            "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+            "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+            "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+            "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+            "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+            "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+            "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+            "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+            "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+            "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+            "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+            "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+            "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+            "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+            "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+            "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+            "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@shikijs/core": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+            "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/primitive": "4.0.2",
+                "@shikijs/types": "4.0.2",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.5"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/@shikijs/engine-javascript": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.6.0.tgz",
-            "integrity": "sha512-7YnLhZG/TU05IHMG14QaLvTW/9WiK8SEYafceccHUSXs2Qr5vJibUwsDfXDLmRi0zHdzsxrGKpSX6hnqe0k8nA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+            "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.6.0",
+                "@shikijs/types": "4.0.2",
                 "@shikijs/vscode-textmate": "^10.0.2",
-                "oniguruma-to-es": "^4.3.3"
+                "oniguruma-to-es": "^4.3.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.6.0.tgz",
-            "integrity": "sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+            "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.6.0",
+                "@shikijs/types": "4.0.2",
                 "@shikijs/vscode-textmate": "^10.0.2"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/@shikijs/langs": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.6.0.tgz",
-            "integrity": "sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+            "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.6.0"
+                "@shikijs/types": "4.0.2"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/@shikijs/themes": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.6.0.tgz",
-            "integrity": "sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+            "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.6.0"
+                "@shikijs/types": "4.0.2"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/@shikijs/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/astro/node_modules/argparse": {
@@ -4318,9 +4431,9 @@
             "license": "Python-2.0"
         },
         "node_modules/astro/node_modules/ci-info": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-            "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
             "funding": [
                 {
                     "type": "github",
@@ -4332,10 +4445,66 @@
                 "node": ">=8"
             }
         },
+        "node_modules/astro/node_modules/common-ancestor-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+            "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/astro/node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "license": "MIT"
+        },
+        "node_modules/astro/node_modules/esbuild": {
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+            "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.4",
+                "@esbuild/android-arm": "0.27.4",
+                "@esbuild/android-arm64": "0.27.4",
+                "@esbuild/android-x64": "0.27.4",
+                "@esbuild/darwin-arm64": "0.27.4",
+                "@esbuild/darwin-x64": "0.27.4",
+                "@esbuild/freebsd-arm64": "0.27.4",
+                "@esbuild/freebsd-x64": "0.27.4",
+                "@esbuild/linux-arm": "0.27.4",
+                "@esbuild/linux-arm64": "0.27.4",
+                "@esbuild/linux-ia32": "0.27.4",
+                "@esbuild/linux-loong64": "0.27.4",
+                "@esbuild/linux-mips64el": "0.27.4",
+                "@esbuild/linux-ppc64": "0.27.4",
+                "@esbuild/linux-riscv64": "0.27.4",
+                "@esbuild/linux-s390x": "0.27.4",
+                "@esbuild/linux-x64": "0.27.4",
+                "@esbuild/netbsd-arm64": "0.27.4",
+                "@esbuild/netbsd-x64": "0.27.4",
+                "@esbuild/openbsd-arm64": "0.27.4",
+                "@esbuild/openbsd-x64": "0.27.4",
+                "@esbuild/openharmony-arm64": "0.27.4",
+                "@esbuild/sunos-x64": "0.27.4",
+                "@esbuild/win32-arm64": "0.27.4",
+                "@esbuild/win32-ia32": "0.27.4",
+                "@esbuild/win32-x64": "0.27.4"
+            }
+        },
         "node_modules/astro/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -4344,42 +4513,81 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/astro/node_modules/magicast": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
+            }
+        },
         "node_modules/astro/node_modules/oniguruma-to-es": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
-            "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+            "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
             "license": "MIT",
             "dependencies": {
                 "oniguruma-parser": "^0.12.1",
-                "regex": "^6.0.1",
+                "regex": "^6.1.0",
                 "regex-recursion": "^6.0.2"
             }
         },
         "node_modules/astro/node_modules/p-limit": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-            "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+            "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
             "license": "MIT",
             "dependencies": {
-                "yocto-queue": "^1.1.1"
+                "yocto-queue": "^1.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/astro/node_modules/p-queue": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+            "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^5.0.1",
+                "p-timeout": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/astro/node_modules/p-timeout": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+            "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/astro/node_modules/package-manager-detector": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
-            "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
             "license": "MIT"
         },
         "node_modules/astro/node_modules/regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
-            "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+            "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
             "license": "MIT",
             "dependencies": {
                 "regex-utilities": "^2.3.0"
@@ -4395,19 +4603,123 @@
             }
         },
         "node_modules/astro/node_modules/shiki": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.6.0.tgz",
-            "integrity": "sha512-tKn/Y0MGBTffQoklaATXmTqDU02zx8NYBGQ+F6gy87/YjKbizcLd+Cybh/0ZtOBX9r1NEnAy/GTRDKtOsc1L9w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+            "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "3.6.0",
-                "@shikijs/engine-javascript": "3.6.0",
-                "@shikijs/engine-oniguruma": "3.6.0",
-                "@shikijs/langs": "3.6.0",
-                "@shikijs/themes": "3.6.0",
-                "@shikijs/types": "3.6.0",
+                "@shikijs/core": "4.0.2",
+                "@shikijs/engine-javascript": "4.0.2",
+                "@shikijs/engine-oniguruma": "4.0.2",
+                "@shikijs/langs": "4.0.2",
+                "@shikijs/themes": "4.0.2",
+                "@shikijs/types": "4.0.2",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/astro/node_modules/tinyexec": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/astro/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/astro/node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/axobject-query": {
@@ -4439,6 +4751,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/bare-events": {
@@ -4505,12 +4818,6 @@
                 }
             }
         },
-        "node_modules/base-64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-            "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-            "license": "MIT"
-        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4553,54 +4860,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/blob-to-buffer": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz",
-            "integrity": "sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true,
             "license": "ISC"
-        },
-        "node_modules/boxen": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-            "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-align": "^3.0.1",
-                "camelcase": "^8.0.0",
-                "chalk": "^5.3.0",
-                "cli-boxes": "^3.0.0",
-                "string-width": "^7.2.0",
-                "type-fest": "^4.21.0",
-                "widest-line": "^5.0.0",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4617,21 +4881,13 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/brotli": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.1.2"
             }
         },
         "node_modules/browserslist": {
@@ -4735,18 +4991,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelcase": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-            "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001695",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
@@ -4793,18 +5037,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/chalk": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/character-entities": {
@@ -4951,18 +5183,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cli-boxes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5029,15 +5249,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/clone": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5045,20 +5256,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/color": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-convert": "^2.0.1",
-                "color-string": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=12.5.0"
             }
         },
         "node_modules/color-convert": {
@@ -5079,17 +5276,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -5109,12 +5295,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/common-ancestor-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-            "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-            "license": "ISC"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -5148,12 +5328,16 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-            "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/cookie-es": {
@@ -5206,15 +5390,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/cross-fetch": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-            "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "node-fetch": "^2.7.0"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5243,7 +5418,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
             "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
@@ -5257,13 +5431,13 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.12.2",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -5273,7 +5447,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
@@ -5282,17 +5455,38 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/cssesc": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
             "license": "MIT",
-            "bin": {
-                "cssesc": "bin/cssesc"
+            "dependencies": {
+                "css-tree": "~2.2.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
             }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "license": "CC0-1.0"
         },
         "node_modules/data-uri-to-buffer": {
             "version": "6.0.2",
@@ -5311,9 +5505,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -5340,12 +5534,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/dedent-js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-            "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
-            "license": "MIT"
-        },
         "node_modules/deep-eql": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -5362,15 +5550,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/defu": {
             "version": "6.1.4",
@@ -5418,31 +5597,19 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/deterministic-object-hash": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-            "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "base-64": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/devalue": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
-            "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+            "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
             "license": "MIT"
         },
         "node_modules/devlop": {
@@ -5464,16 +5631,10 @@
             "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/dfa": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-            "license": "MIT"
-        },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+            "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
@@ -5498,15 +5659,10 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "license": "MIT"
         },
-        "node_modules/docs": {
-            "resolved": "docs",
-            "link": true
-        },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
@@ -5521,7 +5677,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5534,7 +5689,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
@@ -5550,7 +5704,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
             "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
@@ -5609,18 +5762,6 @@
                 "@emmetio/abbreviation": "^2.3.3",
                 "@emmetio/css-abbreviation": "^2.1.8"
             }
-        },
-        "node_modules/emoji-regex": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-            "license": "MIT"
-        },
-        "node_modules/emoji-regex-xs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-            "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-            "license": "MIT"
         },
         "node_modules/encoding-sniffer": {
             "version": "0.2.0",
@@ -5704,15 +5845,17 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.25.5",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
             "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -6106,12 +6249,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/esm-env": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-            "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-            "license": "MIT"
-        },
         "node_modules/espree": {
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -6156,15 +6293,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/esrap": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.3.tgz",
-            "integrity": "sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -6191,6 +6319,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -6206,9 +6335,9 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
         },
         "node_modules/expect-type": {
@@ -6298,6 +6427,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -6314,6 +6444,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -6337,9 +6468,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "funding": [
                 {
                     "type": "github",
@@ -6356,6 +6487,7 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
             "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -6371,10 +6503,13 @@
             }
         },
         "node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -6401,6 +6536,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -6466,30 +6602,24 @@
             }
         },
         "node_modules/fontace": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.3.0.tgz",
-            "integrity": "sha512-czoqATrcnxgWb/nAkfyIrRp6Q8biYj7nGnL6zfhTcX+JKKpWHFBnb8uNMw/kZr7u++3Y3wYSYoZgHkCcsuBpBg==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+            "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
             "license": "MIT",
             "dependencies": {
-                "@types/fontkit": "^2.0.8",
-                "fontkit": "^2.0.4"
+                "fontkitten": "^1.0.2"
             }
         },
-        "node_modules/fontkit": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-            "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+        "node_modules/fontkitten": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+            "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
             "license": "MIT",
             "dependencies": {
-                "@swc/helpers": "^0.5.12",
-                "brotli": "^1.3.2",
-                "clone": "^2.1.2",
-                "dfa": "^1.2.0",
-                "fast-deep-equal": "^3.1.3",
-                "restructure": "^3.0.0",
-                "tiny-inflate": "^1.0.3",
-                "unicode-properties": "^1.4.0",
-                "unicode-trie": "^2.0.0"
+                "tiny-inflate": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/foreground-child": {
@@ -6555,18 +6685,6 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/get-east-asian-width": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-stream": {
@@ -6729,19 +6847,19 @@
             "license": "MIT"
         },
         "node_modules/h3": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.3.tgz",
-            "integrity": "sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.6.tgz",
+            "integrity": "sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ==",
             "license": "MIT",
             "dependencies": {
                 "cookie-es": "^1.2.2",
-                "crossws": "^0.3.4",
+                "crossws": "^0.3.5",
                 "defu": "^6.1.4",
                 "destr": "^2.0.5",
                 "iron-webcrypto": "^1.2.1",
-                "node-mock-http": "^1.0.0",
+                "node-mock-http": "^1.0.4",
                 "radix3": "^1.1.2",
-                "ufo": "^1.6.1",
+                "ufo": "^1.6.3",
                 "uncrypto": "^0.1.3"
             }
         },
@@ -6793,19 +6911,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hast-util-heading-rank": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-            "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/hast-util-is-element": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -6851,21 +6956,6 @@
                 "vfile": "^6.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-sanitize": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
-            "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "unist-util-position": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -7007,9 +7097,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
@@ -7113,16 +7203,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/import-meta-resolve": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-            "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7186,6 +7266,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7204,6 +7285,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -7234,6 +7316,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -7249,15 +7332,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-reference": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
-            "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.6"
             }
         },
         "node_modules/is-subdir": {
@@ -7563,15 +7637,6 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
-        "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
         "node_modules/load-tsconfig": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -7581,12 +7646,6 @@
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
-        },
-        "node_modules/locate-character": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-            "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-            "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "5.0.0",
@@ -7645,15 +7704,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lower-case": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7664,25 +7714,20 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/lunr": {
-            "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-            "license": "MIT"
-        },
         "node_modules/magic-string": {
-            "version": "0.30.17",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/magicast": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
             "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.4",
@@ -7694,6 +7739,7 @@
             "version": "7.26.5",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
             "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -7718,29 +7764,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
         },
         "node_modules/markdown-table": {
             "version": "3.0.4",
@@ -7990,21 +8013,16 @@
             }
         },
         "node_modules/mdn-data": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
-        },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -8577,6 +8595,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -8590,6 +8609,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -8739,20 +8759,11 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/no-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-            "license": "MIT",
-            "dependencies": {
-                "lower-case": "^2.0.2",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -8770,15 +8781,15 @@
             }
         },
         "node_modules/node-fetch-native": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-            "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
             "license": "MIT"
         },
         "node_modules/node-mock-http": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.0.tgz",
-            "integrity": "sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+            "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
             "license": "MIT"
         },
         "node_modules/node-releases": {
@@ -8801,7 +8812,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
@@ -8820,15 +8830,25 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
         "node_modules/ofetch": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
-            "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+            "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
             "license": "MIT",
             "dependencies": {
-                "destr": "^2.0.3",
-                "node-fetch-native": "^1.6.4",
-                "ufo": "^1.5.4"
+                "destr": "^2.0.5",
+                "node-fetch-native": "^1.6.7",
+                "ufo": "^1.6.1"
             }
         },
         "node_modules/ohash": {
@@ -8851,17 +8871,6 @@
             "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
             "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
             "license": "MIT"
-        },
-        "node_modules/oniguruma-to-es": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-            "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex-xs": "^1.0.0",
-                "regex": "^5.1.1",
-                "regex-recursion": "^5.1.1"
-            }
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -8962,34 +8971,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-queue": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-            "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1",
-                "p-timeout": "^6.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -9045,22 +9026,6 @@
             "integrity": "sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pagefind": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.3.0.tgz",
-            "integrity": "sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==",
-            "license": "MIT",
-            "bin": {
-                "pagefind": "lib/runner/bin.cjs"
-            },
-            "optionalDependencies": {
-                "@pagefind/darwin-arm64": "1.3.0",
-                "@pagefind/darwin-x64": "1.3.0",
-                "@pagefind/linux-arm64": "1.3.0",
-                "@pagefind/linux-x64": "1.3.0",
-                "@pagefind/windows-x64": "1.3.0"
-            }
         },
         "node_modules/pako": {
             "version": "1.0.11",
@@ -9153,16 +9118,6 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
-        "node_modules/pascal-case": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-            "license": "MIT",
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/path-browserify": {
@@ -9323,6 +9278,12 @@
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "license": "MIT"
         },
+        "node_modules/piccolore": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+            "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+            "license": "ISC"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9330,9 +9291,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -9374,9 +9335,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-            "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9455,10 +9416,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-            "devOptional": true,
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -9486,28 +9446,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/prompts/node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/property-information": {
@@ -9569,15 +9507,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9669,6 +9598,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9733,25 +9663,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/regex": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
-            "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
-            "license": "MIT",
-            "dependencies": {
-                "regex-utilities": "^2.3.0"
-            }
-        },
-        "node_modules/regex-recursion": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
-            "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
-            "license": "MIT",
-            "dependencies": {
-                "regex": "^5.1.1",
-                "regex-utilities": "^2.3.0"
-            }
-        },
         "node_modules/regex-utilities": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
@@ -9768,24 +9679,6 @@
                 "rehype-parse": "^9.0.0",
                 "rehype-stringify": "^10.0.0",
                 "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-autolink-headings": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
-            "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "hast-util-heading-rank": "^3.0.0",
-                "hast-util-is-element": "^3.0.0",
-                "unified": "^11.0.0",
-                "unist-util-visit": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -9816,20 +9709,6 @@
                 "@types/hast": "^3.0.0",
                 "hast-util-raw": "^9.0.0",
                 "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-sanitize": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
-            "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-sanitize": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -9976,12 +9855,6 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/restructure": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-            "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-            "license": "MIT"
-        },
         "node_modules/retext": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -10047,6 +9920,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -10096,6 +9970,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10123,15 +9998,18 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-            "license": "ISC"
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -10141,16 +10019,16 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.3",
-                "semver": "^7.6.3"
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -10159,25 +10037,30 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.33.5",
-                "@img/sharp-darwin-x64": "0.33.5",
-                "@img/sharp-libvips-darwin-arm64": "1.0.4",
-                "@img/sharp-libvips-darwin-x64": "1.0.4",
-                "@img/sharp-libvips-linux-arm": "1.0.5",
-                "@img/sharp-libvips-linux-arm64": "1.0.4",
-                "@img/sharp-libvips-linux-s390x": "1.0.4",
-                "@img/sharp-libvips-linux-x64": "1.0.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-                "@img/sharp-linux-arm": "0.33.5",
-                "@img/sharp-linux-arm64": "0.33.5",
-                "@img/sharp-linux-s390x": "0.33.5",
-                "@img/sharp-linux-x64": "0.33.5",
-                "@img/sharp-linuxmusl-arm64": "0.33.5",
-                "@img/sharp-linuxmusl-x64": "0.33.5",
-                "@img/sharp-wasm32": "0.33.5",
-                "@img/sharp-win32-ia32": "0.33.5",
-                "@img/sharp-win32-x64": "0.33.5"
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/shebang-command": {
@@ -10203,22 +10086,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shiki": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.1.tgz",
-            "integrity": "sha512-TghWKV9pJTd/N+IgAIVJtr0qZkB7FfFCUrrEJc0aRmZupo3D1OCVRknQWVRVA7AX/M0Ld7QfoAruPzr3CnUJuw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/core": "1.29.1",
-                "@shikijs/engine-javascript": "1.29.1",
-                "@shikijs/engine-oniguruma": "1.29.1",
-                "@shikijs/langs": "1.29.1",
-                "@shikijs/themes": "1.29.1",
-                "@shikijs/types": "1.29.1",
-                "@shikijs/vscode-textmate": "^10.0.1",
-                "@types/hast": "^3.0.4"
-            }
-        },
         "node_modules/siginfo": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -10239,52 +10106,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "license": "MIT"
-        },
-        "node_modules/sitemap": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
-            "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "^17.0.5",
-                "@types/sax": "^1.2.1",
-                "arg": "^5.0.0",
-                "sax": "^1.2.4"
-            },
-            "bin": {
-                "sitemap": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=14.0.0",
-                "npm": ">=6.0.0"
-            }
-        },
-        "node_modules/sitemap/node_modules/@types/node": {
-            "version": "17.0.45",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
             "license": "MIT"
         },
         "node_modules/slash": {
@@ -10308,9 +10133,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
-            "integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+            "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 18"
@@ -10408,12 +10233,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/stream-replace-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
-            "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
-            "license": "MIT"
-        },
         "node_modules/streamx": {
             "version": "2.21.1",
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
@@ -10426,23 +10245,6 @@
             },
             "optionalDependencies": {
                 "bare-events": "^2.2.0"
-            }
-        },
-        "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/string-width-cjs": {
@@ -10467,33 +10269,6 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
         },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
@@ -10681,43 +10456,38 @@
                 "node": ">=8"
             }
         },
-        "node_modules/svelte": {
-            "version": "5.19.2",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.19.2.tgz",
-            "integrity": "sha512-Ww1uLgdX5MdQrAO5zfU1dWUh6zqiPR6uIbwqm8a+4eQ+tNEYHRPgypvKKfHh9lmTkmJ30PWZ2O5qX8aS+PblRQ==",
+        "node_modules/svgo": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.3.0",
-                "@jridgewell/sourcemap-codec": "^1.5.0",
-                "@types/estree": "^1.0.5",
-                "acorn": "^8.12.1",
-                "acorn-typescript": "^1.4.13",
-                "aria-query": "^5.3.1",
-                "axobject-query": "^4.1.0",
-                "clsx": "^2.1.1",
-                "esm-env": "^1.2.1",
-                "esrap": "^1.4.3",
-                "is-reference": "^3.0.3",
-                "locate-character": "^3.0.0",
-                "magic-string": "^0.30.11",
-                "zimmerframe": "^1.1.2"
+                "commander": "^11.1.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^3.0.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.1.1",
+                "sax": "^1.5.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
             }
         },
-        "node_modules/svelte2tsx": {
-            "version": "0.7.34",
-            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.34.tgz",
-            "integrity": "sha512-WTMhpNhFf8/h3SMtR5dkdSy2qfveomkhYei/QW9gSPccb0/b82tjHvLop6vT303ZkGswU/da1s6XvrLgthQPCw==",
+        "node_modules/svgo/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "license": "MIT",
-            "dependencies": {
-                "dedent-js": "^1.0.1",
-                "pascal-case": "^3.1.1"
-            },
-            "peerDependencies": {
-                "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
-                "typescript": "^4.9.4 || ^5.0.0"
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/tapable": {
@@ -10921,20 +10691,30 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyclip": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
+            "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >= 17.3.0"
+            }
+        },
         "node_modules/tinyexec": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
             "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -11000,6 +10780,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -11012,6 +10793,7 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tree-kill": {
@@ -11198,69 +10980,11 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-fest": {
-            "version": "4.33.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-            "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/typed-query-selector": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
             "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
             "license": "MIT"
-        },
-        "node_modules/typedoc": {
-            "version": "0.27.6",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-            "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@gerrit0/mini-shiki": "^1.24.0",
-                "lunr": "^2.3.9",
-                "markdown-it": "^14.1.0",
-                "minimatch": "^9.0.5",
-                "yaml": "^2.6.1"
-            },
-            "bin": {
-                "typedoc": "bin/typedoc"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
-            }
-        },
-        "node_modules/typedoc/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/typedoc/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/typesafe-path": {
             "version": "0.2.2",
@@ -11282,9 +11006,9 @@
             }
         },
         "node_modules/typescript-auto-import-cache": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.5.tgz",
-            "integrity": "sha512-fAIveQKsoYj55CozUiBoj4b/7WpN0i4o74wiGY5JVUEoD0XiqDk1tJqTEjgzL2/AizKQrXxyRosSebyDzBZKjw==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+            "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.8"
@@ -11313,16 +11037,10 @@
                 "typescript": ">=4.8.4 <5.8.0"
             }
         },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT"
-        },
         "node_modules/ufo": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-            "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+            "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
             "license": "MIT"
         },
         "node_modules/ultrahtml": {
@@ -11361,32 +11079,7 @@
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-            "license": "MIT"
-        },
-        "node_modules/unicode-properties": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.0",
-                "unicode-trie": "^2.0.0"
-            }
-        },
-        "node_modules/unicode-trie": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "pako": "^0.2.5",
-                "tiny-inflate": "^1.0.0"
-            }
-        },
-        "node_modules/unicode-trie/node_modules/pako": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/unified": {
@@ -11409,13 +11102,14 @@
             }
         },
         "node_modules/unifont": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.5.0.tgz",
-            "integrity": "sha512-4DueXMP5Hy4n607sh+vJ+rajoLu778aU3GzqeTCqsD/EaUcvqZT9wPC8kgK6Vjh22ZskrxyRCR71FwNOaYn6jA==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+            "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
             "license": "MIT",
             "dependencies": {
-                "css-tree": "^3.0.0",
-                "ohash": "^2.0.0"
+                "css-tree": "^3.1.0",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11"
             }
         },
         "node_modules/unist-util-find-after": {
@@ -11500,9 +11194,9 @@
             }
         },
         "node_modules/unist-util-visit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -11528,9 +11222,9 @@
             }
         },
         "node_modules/unist-util-visit-parents": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -11552,19 +11246,19 @@
             }
         },
         "node_modules/unstorage": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.16.0.tgz",
-            "integrity": "sha512-WQ37/H5A7LcRPWfYOrDa1Ys02xAbpPJq6q5GkO88FBXVSQzHd7+BjEwfRqyaSWCv9MbsJy058GWjjPjcJ16GGA==",
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
+            "integrity": "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==",
             "license": "MIT",
             "dependencies": {
                 "anymatch": "^3.1.3",
-                "chokidar": "^4.0.3",
+                "chokidar": "^5.0.0",
                 "destr": "^2.0.5",
-                "h3": "^1.15.2",
-                "lru-cache": "^10.4.3",
-                "node-fetch-native": "^1.6.6",
-                "ofetch": "^1.4.1",
-                "ufo": "^1.6.1"
+                "h3": "^1.15.5",
+                "lru-cache": "^11.2.0",
+                "node-fetch-native": "^1.6.7",
+                "ofetch": "^1.5.1",
+                "ufo": "^1.6.3"
             },
             "peerDependencies": {
                 "@azure/app-configuration": "^1.8.0",
@@ -11573,13 +11267,14 @@
                 "@azure/identity": "^4.6.0",
                 "@azure/keyvault-secrets": "^4.9.0",
                 "@azure/storage-blob": "^12.26.0",
-                "@capacitor/preferences": "^6.0.3 || ^7.0.0",
+                "@capacitor/preferences": "^6 || ^7 || ^8",
                 "@deno/kv": ">=0.9.0",
-                "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0",
+                "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
                 "@planetscale/database": "^1.19.0",
                 "@upstash/redis": "^1.34.3",
                 "@vercel/blob": ">=0.27.1",
-                "@vercel/kv": "^1.0.1",
+                "@vercel/functions": "^2.2.12 || ^3.0.0",
+                "@vercel/kv": "^1 || ^2 || ^3",
                 "aws4fetch": "^1.0.20",
                 "db0": ">=0.2.1",
                 "idb-keyval": "^6.2.1",
@@ -11623,6 +11318,9 @@
                 "@vercel/blob": {
                     "optional": true
                 },
+                "@vercel/functions": {
+                    "optional": true
+                },
                 "@vercel/kv": {
                     "optional": true
                 },
@@ -11643,11 +11341,42 @@
                 }
             }
         },
+        "node_modules/unstorage/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/unstorage/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC"
+            "version": "11.2.7",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/unstorage/node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.2",
@@ -11733,9 +11462,10 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
@@ -11830,16 +11560,17 @@
             }
         },
         "node_modules/vitefu": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.6.tgz",
-            "integrity": "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.2.tgz",
+            "integrity": "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==",
             "license": "MIT",
             "workspaces": [
                 "tests/deps/*",
-                "tests/projects/*"
+                "tests/projects/*",
+                "tests/projects/workspace/packages/*"
             ],
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0"
             },
             "peerDependenciesMeta": {
                 "vite": {
@@ -11918,9 +11649,9 @@
             }
         },
         "node_modules/volar-service-css": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.62.tgz",
-            "integrity": "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.68.tgz",
+            "integrity": "sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q==",
             "license": "MIT",
             "dependencies": {
                 "vscode-css-languageservice": "^6.3.0",
@@ -11937,12 +11668,12 @@
             }
         },
         "node_modules/volar-service-emmet": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.62.tgz",
-            "integrity": "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.68.tgz",
+            "integrity": "sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ==",
             "license": "MIT",
             "dependencies": {
-                "@emmetio/css-parser": "^0.4.0",
+                "@emmetio/css-parser": "^0.4.1",
                 "@emmetio/html-matcher": "^1.3.0",
                 "@vscode/emmet-helper": "^2.9.3",
                 "vscode-uri": "^3.0.8"
@@ -11957,9 +11688,9 @@
             }
         },
         "node_modules/volar-service-html": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.62.tgz",
-            "integrity": "sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.68.tgz",
+            "integrity": "sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA==",
             "license": "MIT",
             "dependencies": {
                 "vscode-html-languageservice": "^5.3.0",
@@ -11976,9 +11707,9 @@
             }
         },
         "node_modules/volar-service-prettier": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.62.tgz",
-            "integrity": "sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.68.tgz",
+            "integrity": "sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw==",
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.8"
@@ -11997,14 +11728,14 @@
             }
         },
         "node_modules/volar-service-typescript": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.62.tgz",
-            "integrity": "sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.68.tgz",
+            "integrity": "sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw==",
             "license": "MIT",
             "dependencies": {
                 "path-browserify": "^1.0.1",
                 "semver": "^7.6.2",
-                "typescript-auto-import-cache": "^0.3.3",
+                "typescript-auto-import-cache": "^0.3.5",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-nls": "^5.2.0",
                 "vscode-uri": "^3.0.8"
@@ -12019,9 +11750,9 @@
             }
         },
         "node_modules/volar-service-typescript-twoslash-queries": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.62.tgz",
-            "integrity": "sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.68.tgz",
+            "integrity": "sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w==",
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.8"
@@ -12036,13 +11767,13 @@
             }
         },
         "node_modules/volar-service-yaml": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.62.tgz",
-            "integrity": "sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==",
+            "version": "0.0.68",
+            "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.68.tgz",
+            "integrity": "sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA==",
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.8",
-                "yaml-language-server": "~1.15.0"
+                "yaml-language-server": "~1.19.2"
             },
             "peerDependencies": {
                 "@volar/language-service": "~2.4.0"
@@ -12054,27 +11785,27 @@
             }
         },
         "node_modules/vscode-css-languageservice": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.2.tgz",
-            "integrity": "sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==",
+            "version": "6.3.10",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+            "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.18",
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "3.17.5",
-                "vscode-uri": "^3.0.8"
+                "vscode-uri": "^3.1.0"
             }
         },
         "node_modules/vscode-html-languageservice": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
-            "integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+            "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.18",
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5",
-                "vscode-uri": "^3.0.8"
+                "vscode-uri": "^3.1.0"
             }
         },
         "node_modules/vscode-json-languageservice": {
@@ -12149,9 +11880,9 @@
             "license": "MIT"
         },
         "node_modules/vscode-uri": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "license": "MIT"
         },
         "node_modules/web-namespaces": {
@@ -12168,6 +11899,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-encoding": {
@@ -12197,6 +11929,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
@@ -12245,21 +11978,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/widest-line": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -12268,23 +11986,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/wrap-ansi-cjs": {
@@ -12344,33 +12045,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12421,45 +12095,47 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yaml-language-server": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.15.0.tgz",
-            "integrity": "sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.19.2.tgz",
+            "integrity": "sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg==",
             "license": "MIT",
             "dependencies": {
-                "ajv": "^8.11.0",
+                "@vscode/l10n": "^0.0.18",
+                "ajv": "^8.17.1",
+                "ajv-draft-04": "^1.0.0",
                 "lodash": "4.17.21",
+                "prettier": "^3.5.0",
                 "request-light": "^0.5.7",
                 "vscode-json-languageservice": "4.1.8",
-                "vscode-languageserver": "^7.0.0",
+                "vscode-languageserver": "^9.0.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.16.0",
-                "vscode-nls": "^5.0.0",
                 "vscode-uri": "^3.0.2",
-                "yaml": "2.2.2"
+                "yaml": "2.7.1"
             },
             "bin": {
                 "yaml-language-server": "bin/yaml-language-server"
-            },
-            "optionalDependencies": {
-                "prettier": "2.8.7"
             }
         },
         "node_modules/yaml-language-server/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -12472,27 +12148,25 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
-        },
-        "node_modules/yaml-language-server/node_modules/prettier": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
         },
         "node_modules/yaml-language-server/node_modules/request-light": {
             "version": "0.5.8",
@@ -12500,48 +12174,14 @@
             "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
             "license": "MIT"
         },
-        "node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
-            }
-        },
-        "node_modules/yaml-language-server/node_modules/vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.16.0"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/yaml-language-server/node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
-            }
-        },
-        "node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
-            "license": "MIT"
-        },
         "node_modules/yaml-language-server/node_modules/yaml": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
                 "node": ">= 14"
             }
@@ -12604,75 +12244,15 @@
             }
         },
         "node_modules/yocto-queue": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yocto-spinner": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-            "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-            "license": "MIT",
-            "dependencies": {
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=18.19"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yoctocolors": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-            "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zimmerframe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
-            "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-            "license": "MIT"
-        },
-        "node_modules/zod": {
-            "version": "3.25.58",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.58.tgz",
-            "integrity": "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.24.5",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-            "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
-            }
-        },
-        "node_modules/zod-to-ts": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-            "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-            "peerDependencies": {
-                "typescript": "^4.9.4 || ^5.0.2",
-                "zod": "^3"
             }
         },
         "node_modules/zwitch": {
@@ -12688,8 +12268,8 @@
         "test/fixtures/build-pdf": {
             "name": "@test/build-pdf",
             "devDependencies": {
-                "@astrojs/check": "^0.9.4",
-                "astro": "^5.0.3",
+                "@astrojs/check": "^0.9.7",
+                "astro": "^6.0.4",
                 "astro-pdf": "^1.7.2",
                 "typescript": "^5.6.2"
             }
@@ -12697,7 +12277,7 @@
         "test/fixtures/concurrent": {
             "name": "@test/concurrent",
             "devDependencies": {
-                "astro": "^5.0.3",
+                "astro": "^6.0.4",
                 "astro-pdf": "^1.7.2",
                 "typescript": "^5.6.2"
             }
@@ -12705,8 +12285,8 @@
         "test/fixtures/merge-pdfs": {
             "name": "@test/merge-pdfs",
             "dependencies": {
-                "@astrojs/check": "^0.9.4",
-                "astro": "^5.1.1",
+                "@astrojs/check": "^0.9.7",
+                "astro": "^6.0.4",
                 "astro-pdf": "^1.7.2",
                 "pdf-merger-js": "^5.1.2",
                 "typescript": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "puppeteer": "^23.10.1"
     },
     "peerDependencies": {
-        "astro": "^4.4.4 || ^5.0.0"
+        "astro": "^4.4.4 || ^5.0.0 || ^6.0.0"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
@@ -52,7 +52,7 @@
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/node": "^22.10.1",
         "@vitest/coverage-istanbul": "^3.0.3",
-        "astro": "^5.0.3",
+        "astro": "^6.0.4",
         "cheerio": "^1.0.0",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -67,7 +67,6 @@
     },
     "workspaces": [
         "./",
-        "./docs",
         "./test/fixtures/**"
     ],
     "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "prepack": "npm run build && npm test",
         "test": "tsc -p test && vitest run",
         "coverage": "vitest run --coverage",
-        "lint": "eslint",
+        "lint": "eslint src test eslint.config.js vitest.config.ts tsup.config.ts",
+        "lint:docs": "eslint docs/astro.config.mjs docs/src/content.config.ts",
         "format": "prettier . --write",
         "format:check": "prettier . --check",
         "version": "changeset version && npm install --lockfile-only"

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,9 +189,7 @@ export default function pdf(options: Options): AstroIntegration {
                                     const time = Date.now() - start
                                     const src = err.src ? dim(' ← ' + err.src) : ''
                                     logger.info(
-                                        red(
-                                            `✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${attempts}`
-                                        )
+                                        red(`✖︎ ${err.location} (${err.title}) ${dim(`(+${time}ms)`)}${src}${attempts}`)
                                     )
                                 }
                                 const causeStack =

--- a/test/custom-server.test.ts
+++ b/test/custom-server.test.ts
@@ -96,7 +96,6 @@ describe('custom server', () => {
             await integration.hooks['astro:build:done']!({
                 pages: [],
                 dir: new URL('dist', root),
-                routes: [],
                 logger,
                 assets: new Map()
             })
@@ -144,7 +143,6 @@ describe('custom server', () => {
             await integration.hooks['astro:build:done']!({
                 pages: [],
                 dir: new URL('dist', root),
-                routes: [],
                 logger,
                 assets: new Map()
             })
@@ -199,7 +197,6 @@ describe('custom server', () => {
             const promise = integration.hooks['astro:build:done']!({
                 pages: [],
                 dir: new URL('dist', root),
-                routes: [],
                 logger,
                 assets: new Map()
             })

--- a/test/fixtures/build-pdf/package.json
+++ b/test/fixtures/build-pdf/package.json
@@ -10,8 +10,8 @@
         "astro": "astro"
     },
     "devDependencies": {
-        "@astrojs/check": "^0.9.4",
-        "astro": "^5.0.3",
+        "@astrojs/check": "^0.9.7",
+        "astro": "^6.0.4",
         "astro-pdf": "^1.7.2",
         "typescript": "^5.6.2"
     }

--- a/test/fixtures/concurrent/package.json
+++ b/test/fixtures/concurrent/package.json
@@ -6,7 +6,7 @@
         "build": "astro build"
     },
     "devDependencies": {
-        "astro": "^5.0.3",
+        "astro": "^6.0.4",
         "astro-pdf": "^1.7.2",
         "typescript": "^5.6.2"
     }

--- a/test/fixtures/merge-pdfs/package.json
+++ b/test/fixtures/merge-pdfs/package.json
@@ -9,8 +9,8 @@
         "astro": "astro"
     },
     "dependencies": {
-        "@astrojs/check": "^0.9.4",
-        "astro": "^5.1.1",
+        "@astrojs/check": "^0.9.7",
+        "astro": "^6.0.4",
         "astro-pdf": "^1.7.2",
         "pdf-merger-js": "^5.1.2",
         "typescript": "^5.7.2"

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -102,7 +102,6 @@ describe('run integration', () => {
             await integration.hooks['astro:build:done']!({
                 pages: [],
                 dir: outDir,
-                routes: [],
                 logger,
                 assets: new Map()
             })

--- a/test/process-page.test.ts
+++ b/test/process-page.test.ts
@@ -40,7 +40,7 @@ describe('process page', () => {
         if (existsSync(env.outDir)) {
             await rm(env.outDir, { recursive: true })
         }
-    })
+    }, 30000)
 
     describe('valid page full test', () => {
         const injectedTitle = '@test/process-page | astro-pdf'


### PR DESCRIPTION
This is a simple PR that adds Astro v6 to the dependency range while maintaining support for v4 and v5. Docs is dependent on v5 (as is lameuler/atlas) so I moved that out of the workspace and added workflow steps to install the docs dependencies separately.

Happy to make any changes or submit PRs for the other repos to add v6 support if you don't want to change any of the Docs workflow stuff. Thanks for the great package!

EDIT: This may be too many decisions for a random person submitting a PR. If you decide not to merge it, at least it might give you an idea of the required changes.

## Non-breaking changes
- Added astro `^6.0.0` to peerDependencies
- Updated tests to use astro `^6.0.4`
- Updated `astro:build:done` signature in tests to match v6. See [Removed: routes on astro:build:done hook (Integration API)](https://docs.astro.build/en/guides/upgrade-to/v6/#removed-routes-on-astrobuilddone-hook-integration-api)

## Potentially breaking changes
- Moved `./docs` out of the workspace may impact your builds.
- Added an `npm install` step for docs in the actions workflows.
- Removed Node 18, 20 from CI.
- Changed node-version from 20 to 22
- Added node 24 to CI matrix
- Split up `npm run lint` into `npm run lint` and `npm run lint:docs`

## Tests

<img width="995" height="502" alt="image" src="https://github.com/user-attachments/assets/ac11a8dc-2d28-42e0-8f10-238b57755306" />

---

<img width="1100" height="1331" alt="image" src="https://github.com/user-attachments/assets/ba6bcc00-242d-4ae4-879f-4c776c44650d" />
