### PR TITLE
Fix overriding from options normalized to same location

### DIFF
--- a/.changeset/warm-cows-stand.md
+++ b/.changeset/warm-cows-stand.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+fix edge case where locations in `PagesMap` which are normalized to the same value will override each other's options

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [22, 24.15, 25]
+                node-version: [22, '24.15', '26.0']
         steps:
             - name: Checkout
               uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [22, 24.15, 26.0]
+                node-version: [22, 24.15, 25]
         steps:
             - name: Checkout
               uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                node-version: [22, 24, 25]
+                node-version: [22, 24.15, 26.0]
         steps:
             - name: Checkout
               uses: actions/checkout@v6

--- a/src/options.ts
+++ b/src/options.ts
@@ -432,10 +432,13 @@ export function mergePages(builtPages: { pathname: string }[], pages: PagesFunct
                     }
                 }
                 if (result.length > 0) {
-                    if (url.protocol === 'http:' || url.protocol === 'https:') {
-                        map[url.href] = result
+                    const cleanKey = (url.protocol === 'http:' || url.protocol === 'https:') ? url.href : (url.pathname + url.search)
+                    // it is possible for there to be duplicate keys as the original key is cleaned/normalized
+                    // e.g. '/path' and 'path' are both valid keys which will both become '/path'
+                    if (cleanKey in map) {
+                        map[cleanKey].push(...result)
                     } else {
-                        map[url.pathname + url.search] = result
+                        map[cleanKey] = result
                     }
                 }
             }

--- a/src/options.ts
+++ b/src/options.ts
@@ -432,7 +432,8 @@ export function mergePages(builtPages: { pathname: string }[], pages: PagesFunct
                     }
                 }
                 if (result.length > 0) {
-                    const cleanKey = (url.protocol === 'http:' || url.protocol === 'https:') ? url.href : (url.pathname + url.search)
+                    const cleanKey =
+                        url.protocol === 'http:' || url.protocol === 'https:' ? url.href : url.pathname + url.search
                     // it is possible for there to be duplicate keys as the original key is cleaned/normalized
                     // e.g. '/path' and 'path' are both valid keys which will both become '/path'
                     if (cleanKey in map) {

--- a/test/page-options.test.ts
+++ b/test/page-options.test.ts
@@ -10,14 +10,15 @@ describe('merge pages', () => {
         const pages = {
             path: undefined,
             'https://example.com': [true, 'example.pdf'],
-            'route/c/': [false, undefined, null]
+            'route/c/': [false, undefined, null],
+            '/route/c/': ['null']
         }
         const { map, locations, fallback } = mergePages(routes, pages)
         locations.sort()
         expect(locations).toStrictEqual(['/route/a', '/route/b', '/route/c/', 'https://example.com/'])
         expect(map).toStrictEqual({
             'https://example.com/': [true, 'example.pdf'],
-            '/route/c/': [false]
+            '/route/c/': [false, 'null']
         })
         expect(fallback).toBeDefined()
         expect(fallback('/route/a')).toBeUndefined()


### PR DESCRIPTION
Fixed an edge case where locations which are normalized to the same value in `PagesMap` will override each others options.

For example, `/path` and `path` will both become `/path` in the resolved options map. Previously, one of them would get overridden by the other. This has now been fixed.