### PR TITLE
Deprecate `install` option

### DIFF
--- a/.changeset/green-dragons-know.md
+++ b/.changeset/green-dragons-know.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': minor
+---
+
+⚠️ Deprecated the `install` option. Instead, [configure Puppeteer](https://pptr.dev/guides/configuration) to choose which browser to install or manually install a browser and pass the `executablePath` to the [`launch` option](https://ler.quest/astro-pdf/reference/options#launch). In the next major version, `astro-pdf` will no longer handle the installation of browsers.

--- a/docs/src/content/configuring-puppeteer.md
+++ b/docs/src/content/configuring-puppeteer.md
@@ -3,13 +3,11 @@ title: Configuring Puppeteer
 description: Setup a Puppeteer configuration file to control which browser it installs and uses. Handle common sandbox related issues with Puppeteer on Linux and Windows.
 ---
 
-When `astro-pdf` is installed, it installs `puppeteer`, which will automatically install a recent version of Chrome. However, you can [configure Puppeteer](https://pptr.dev/guides/configuration) to prevent this.
-
-`astro-pdf` also gives you the [option to install a browser](reference/options#install) when it runs.
+When `astro-pdf` is installed, it installs `puppeteer`, which will automatically install a recent version of Chrome. However, you can [configure Puppeteer](https://pptr.dev/guides/configuration) to prevent this or change which browser and version it installs.
 
 ## Puppeteer config file
 
-The [Puppeteer config file](https://pptr.dev/guides/configuration#configuration-files) can be used to set the browsers installed, the location to install browsers, and more. Refer to the [Puppeteer API documentation](https://pptr.dev/api/puppeteer.configuration) for all the options.
+The [Puppeteer config file](https://pptr.dev/guides/configuration#configuration-files) can be used to set which browsers to install, the location to install browsers, and more. Refer to the [Puppeteer API documentation](https://pptr.dev/api/puppeteer.configuration) for all the options.
 
 ### Install browser with CLI
 
@@ -29,7 +27,7 @@ npx puppeteer browsers install chrome@131.0.6778.204
 
 ### Skip browser download
 
-To stop Puppeteer from downloading a browser by default, you can set `skipDownload` to `true` in you Puppeteer config file.
+To stop Puppeteer from downloading a browser by default, you can set `skipDownload` to `true` in your Puppeteer config file.
 
 ```js
 {
@@ -37,13 +35,13 @@ To stop Puppeteer from downloading a browser by default, you can set `skipDownlo
 }
 ```
 
-You can also set `PUPPETEER_SKIP_DOWNLOAD` environment variable when installing `astro-pdf` (or `puppeteer`) to prevent it from installing a browser.
+You can also set the `PUPPETEER_SKIP_DOWNLOAD` environment variable when installing `astro-pdf` (or `puppeteer`) to prevent it from installing a browser.
 
 ```sh
 PUPPETEER_SKIP_DOWNLOAD=true npm install
 ```
 
-You can then use the [`install` option](reference/options#install) to control which browser to install when `astro-pdf` runs.
+You can then manually install a browser and pass the `executablePath` to the [`launch` option](reference/options#launch).
 
 ## Linux AppArmor profile
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,11 @@ export default function pdf(options: Options): AstroIntegration {
                 logger.info(`\r${bold(bgBlue(' astro-pdf '))} ${versionColour('v' + VERSION)} – generating pdf files`)
 
                 if (options.install !== undefined) {
-                    process.emitWarning('Options.install is deprecated. Configure Puppeteer to choose which browser to install (https://pptr.dev/guides/configuration) or manually install a browser and pass the executablePath to Options.launch.', 'DeprecationWarning', 'astro-pdf:001')
+                    process.emitWarning(
+                        'Options.install is deprecated. Configure Puppeteer to choose which browser to install (https://pptr.dev/guides/configuration) or manually install a browser and pass the executablePath to Options.launch.',
+                        'DeprecationWarning',
+                        'astro-pdf:001'
+                    )
                 }
 
                 try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,10 @@ export default function pdf(options: Options): AstroIntegration {
                 const versionColour = VERSION.includes('-') ? yellow : green
                 logger.info(`\r${bold(bgBlue(' astro-pdf '))} ${versionColour('v' + VERSION)} – generating pdf files`)
 
+                if (options.install !== undefined) {
+                    process.emitWarning('Options.install is deprecated. Configure Puppeteer to choose which browser to install (https://pptr.dev/guides/configuration) or manually install a browser and pass the executablePath to Options.launch.', 'DeprecationWarning', 'astro-pdf:001')
+                }
+
                 try {
                     if (typeof options.runBefore === 'function') {
                         logger.info(dim('running runBefore hook...'))

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,10 +35,10 @@ export interface Options {
      * By default, it will install the latest stable build of Chrome if `install` is truthy and the browser to install is not specified.
      *
      * If `install` is `false` or `undefined`, but no browser is found, it will automatically install a browser.
-     * 
+     *
      * @deprecated
      * {@link https://pptr.dev/guides/configuration Configure Puppeteer} to choose which browser to install or manually install a browser and pass the `executablePath` to {@link Options.launch `launch`}.
-     * 
+     *
      * In the next major version, `astro-pdf` will no longer handle the installation of browsers.
      */
     install?: boolean | Partial<InstallOptions>

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,6 +35,8 @@ export interface Options {
      * By default, it will install the latest stable build of Chrome if `install` is truthy and the browser to install is not specified.
      *
      * If `install` is `false` or `undefined`, but no browser is found, it will automatically install a browser.
+     * 
+     * @deprecated {@link https://pptr.dev/guides/configuration Configure Puppeteer} to choose which browser to install or manually install a browser and pass the `executablePath` to {@link Options.launch `launch`}.
      */
     install?: boolean | Partial<InstallOptions>
     /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,7 +36,10 @@ export interface Options {
      *
      * If `install` is `false` or `undefined`, but no browser is found, it will automatically install a browser.
      * 
-     * @deprecated {@link https://pptr.dev/guides/configuration Configure Puppeteer} to choose which browser to install or manually install a browser and pass the `executablePath` to {@link Options.launch `launch`}.
+     * @deprecated
+     * {@link https://pptr.dev/guides/configuration Configure Puppeteer} to choose which browser to install or manually install a browser and pass the `executablePath` to {@link Options.launch `launch`}.
+     * 
+     * In the next major version, `astro-pdf` will no longer handle the installation of browsers.
      */
     install?: boolean | Partial<InstallOptions>
     /**

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -25,6 +25,7 @@ describe('run integration', () => {
     beforeAll(() => {
         let i = 0
         integration = pdf({
+            install: false,
             pages: {
                 'https://ler.sg/cv': {
                     waitUntil: 'networkidle0',
@@ -69,6 +70,11 @@ describe('run integration', () => {
         const outDir = new URL('./dist', root)
         const outPath = fileURLToPath(outDir)
 
+        const warnings: Error[] = []
+        process.on('warning', (warning) => {
+            warnings.push(warning)
+        })
+
         beforeAll(async () => {
             if (existsSync(outPath)) {
                 await rm(outPath, { recursive: true })
@@ -106,6 +112,10 @@ describe('run integration', () => {
                 assets: new Map()
             })
         }, 30000)
+
+        test('warns for deprecated options', () => {
+            expect(warnings.filter((warning) => warning.name === 'DeprecationWarning').map((warning) => 'code' in warning && warning.code)).toStrictEqual(['astro-pdf:001'])
+        })
 
         test('called runBefore', () => {
             expect(runBefore).toBeCalledTimes(1)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -114,7 +114,11 @@ describe('run integration', () => {
         }, 30000)
 
         test('warns for deprecated options', () => {
-            expect(warnings.filter((warning) => warning.name === 'DeprecationWarning').map((warning) => 'code' in warning && warning.code)).toStrictEqual(['astro-pdf:001'])
+            expect(
+                warnings
+                    .filter((warning) => warning.name === 'DeprecationWarning')
+                    .map((warning) => 'code' in warning && warning.code)
+            ).toStrictEqual(['astro-pdf:001'])
         })
 
         test('called runBefore', () => {


### PR DESCRIPTION
Mark the `install` option as deprecated and to be removed in the next major version of `astro-pdf`.

In the next major version, `astro-pdf` will no longer handle the installation of browsers.

This option is being deprecated/removed as it is a bit redundant and can lead to unexpected behaviour. The installation of browsers should either be handled by Puppeteer itself or fully controlled by the user.

Puppeteer installs Chrome on its own and thus most users would never to care about installing browsers.

Otherwise, the user can customize which browser Puppeteer installs using [Puppeteer's own configuration](https://pptr.dev/guides/configuration), rather than using the `install` option which also uses Puppeteer to install the browser.

Removing this option will also allow the user to control the browser installation on their own instead of using Puppeteer without any unexpected behaviour. (#106)

`astro-pdf` also does not have access to the pinned browser version used internally by Puppeteer that is best guaranteed to work the specific version of Puppeteer.