### PR TITLE
Fix `loadPage` race condition and `throwOnFail` behaviour

### DIFF
--- a/.changeset/common-flowers-stand.md
+++ b/.changeset/common-flowers-stand.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+ensure all pages can run cleanup when an error is thrown (with `throwOnFail: true`)

--- a/.changeset/gold-swans-film.md
+++ b/.changeset/gold-swans-film.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+fixed an issue where a failed page load with `throwOnFail: true` would get logged multiple times

--- a/.changeset/icy-schools-bet.md
+++ b/.changeset/icy-schools-bet.md
@@ -1,0 +1,5 @@
+---
+'astro-pdf': patch
+---
+
+fix a potential race condition when loading pages where the request fails or responds with an error

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,14 @@ import { astroPreview } from './server.js'
 export type { Options, PageOptions, ServerOutput }
 export type { PagesEntry, PagesFunction, PagesMap, PDFOptions } from './options.js'
 
+class PageLoadAborted extends Error {
+    name = 'PageLoadAborted' as const
+
+    constructor(cause: unknown) {
+        super(`page load aborted`, { cause })
+    }
+}
+
 /**
  * Creates the `astro-pdf` integration.
  *
@@ -139,7 +147,9 @@ export default function pdf(options: Options): AstroIntegration {
                     const controller = new AbortController()
 
                     function onDisconnected() {
-                        controller.abort(new FatalError('Fatal error: Browser disconnected unexpectedly'))
+                        controller.abort(
+                            new PageLoadAborted(new FatalError('Fatal error: Browser disconnected unexpectedly'))
+                        )
                     }
                     browser.on('disconnected', onDisconnected)
 
@@ -205,10 +215,14 @@ export default function pdf(options: Options): AstroIntegration {
                                 logger.debug(
                                     bold(red(`error while processing ${location}:\n`)) + err.stack + causeStack
                                 )
+                            } else if (err instanceof FatalError) {
+                                throw err
+                            } else if (err instanceof PageLoadAborted) {
+                                const causeStack =
+                                    err.cause instanceof Error ? `\n${bold('Caused by:')}\n${err.cause.stack}` : ''
+                                logger.debug(`page load aborted for ${location}` + causeStack)
+                                throw err
                             } else {
-                                if (err instanceof FatalError) {
-                                    throw err
-                                }
                                 // wrap unexpected errors with a more useful message
                                 throw new Error(
                                     `An unexpected error occurred and was not handled by astro-pdf while processing \`${location}\`:\n\n` +
@@ -233,15 +247,40 @@ export default function pdf(options: Options): AstroIntegration {
                         if (typeof options.browserCallback === 'function') {
                             await options.browserCallback(browser)
                         }
-                        await pMap(queue, ({ location, pageOptions }) => task(location, pageOptions), {
-                            concurrency,
-                            signal
-                        })
+                        await pMap(
+                            queue,
+                            async ({ location, pageOptions }) => {
+                                try {
+                                    // ensure tasks do not run once aborted
+                                    signal.throwIfAborted()
+                                    await task(location, pageOptions)
+                                } catch (err) {
+                                    // instead of throwing an error, which will immediately cause pMap to throw,
+                                    // it will abort the individual tasks to let them run their cleanup
+                                    if (!(err instanceof PageLoadAborted)) {
+                                        controller.abort(new PageLoadAborted(err))
+                                    }
+                                }
+                            },
+                            {
+                                concurrency
+                            }
+                        )
+                        // throw the error from the first failed task if aborted
+                        signal.throwIfAborted()
                     } catch (err) {
-                        if (!signal.aborted) {
-                            controller.abort(err)
+                        // the err caught here should be signal.reason
+                        if (err instanceof PageLoadAborted) {
+                            throw err.cause
+                        } else {
+                            // all errors should be wrapped by PageLoadAborted
+                            throw new Error(
+                                `An unexpected error occurred and was not handled by astro-pdf:\n\n` +
+                                    err +
+                                    '\n\nConsider filing a bug report at https://github.com/lameuler/astro-pdf/issues/new/choose\n',
+                                { cause: err }
+                            )
                         }
-                        throw err
                     } finally {
                         await browser.off('disconnected', onDisconnected).close()
                         if (typeof close === 'function') {

--- a/src/page.ts
+++ b/src/page.ts
@@ -207,6 +207,7 @@ export async function processPage(location: string, pageOptions: PageOptions, en
             debug(`closing page for \`${location}\` (page.url: ${page.url()})`)
             try {
                 await page.close()
+                debug(`page closed for \`${location}\``)
             } catch (err) {
                 debug(bold(red(`failed to close page for \`${location}\`: `)) + err)
             }
@@ -226,12 +227,6 @@ export async function processPage(location: string, pageOptions: PageOptions, en
                 debug(yellow(`browser context (${context.id}) for \`${location}\` has already been closed`))
             }
         }
-    }
-}
-
-class AbortPageLoad extends Error {
-    constructor() {
-        super('abort signal: abort page load')
     }
 }
 
@@ -263,100 +258,106 @@ export async function loadPage(
     }
     signal?.throwIfAborted()
 
-    return new Promise((resolve, reject) => {
-        let url: URL
-        try {
-            url = new URL(location, baseUrl)
-        } catch (err) {
-            reject(new PageError(location, 'invalid location', { cause: err }))
-            return
+    let url: URL
+    try {
+        url = new URL(location, baseUrl)
+    } catch (err) {
+        throw new PageError(location, 'invalid location', { cause: err })
+    }
+
+    let dest = location
+
+    function rejectedPageError(res: HTTPResponse) {
+        const title = res.status() + (res.statusText() ? ' ' + res.statusText() : '')
+        return new PageError(dest, title, {
+            status: res.status(),
+            src: location
+        })
+    }
+
+    // this is used to interrupt page.goto and will cause it to throw the abort reason
+    // any errors before page.goto settles must be sent via this controller
+    // which interrupts page.goto while ensuring it settles, preventing any race conditions further on
+    const controller = new AbortController()
+
+    // handle aborts from outside loadPage while page.goto is running
+    function onAbort() {
+        controller.abort(signal?.reason)
+    }
+    signal?.addEventListener('abort', onAbort)
+
+    const requestListener = (req: HTTPRequest) => {
+        if (req.url() === new URL(dest, baseUrl).href) {
+            const err = req.failure()?.errorText ?? 'request failed'
+            page.off('response', responseListener)
+            page.off('requestfailed', requestListener)
+            controller.abort(new PageError(dest, err, { src: location }))
         }
+    }
+    page.on('requestfailed', requestListener)
 
-        let dest = location
-
-        function rejectResponse(res: HTTPResponse) {
-            const title = res.status() + (res.statusText() ? ' ' + res.statusText() : '')
-            reject(
-                new PageError(dest, title, {
-                    status: res.status(),
-                    src: location
-                })
-            )
-            signal?.removeEventListener('abort', onAbort)
-        }
-
-        const controller = new AbortController()
-
-        function onAbort() {
-            controller.abort(new AbortPageLoad())
-            signal?.removeEventListener('abort', onAbort)
-            reject(signal?.reason)
-        }
-        signal?.addEventListener('abort', onAbort)
-
-        const requestListener = (req: HTTPRequest) => {
-            if (req.url() === new URL(dest, baseUrl).href) {
-                const err = req.failure()?.errorText ?? 'request failed'
+    const responseListener = (res: HTTPResponse) => {
+        if (res.url() === new URL(dest, baseUrl).href) {
+            const s = res.status()
+            if (s >= 200 && s < 300) {
                 page.off('response', responseListener)
                 page.off('requestfailed', requestListener)
-                controller.abort(new AbortPageLoad())
-                reject(new PageError(dest, err, { src: location }))
-            }
-        }
-        page.on('requestfailed', requestListener)
-
-        const responseListener = (res: HTTPResponse) => {
-            if (res.url() === new URL(dest, baseUrl).href) {
-                const s = res.status()
-                if (s >= 200 && s < 300) {
-                    page.off('response', responseListener)
-                    page.off('requestfailed', requestListener)
-                } else if (s >= 300 && s < 400) {
-                    const location = res.headers()['location']
-                    // check if it is a redirect
-                    // let puppeteer handle 3XX response codes which are not redirects
-                    if (typeof location === 'string') {
-                        const destUrl = new URL(res.headers()['location'], res.url())
-                        dest = destUrl.href
-                        if (baseUrl && dest.startsWith(baseUrl.origin)) {
-                            dest = dest.substring(baseUrl.origin.length)
-                        }
+            } else if (s >= 300 && s < 400) {
+                const location = res.headers()['location']
+                // check if the response is a redirect and if so records the new destination
+                // otherwise it does nothing, letting puppeteer handle 3XX response codes which are not redirects
+                if (typeof location === 'string') {
+                    const destUrl = new URL(res.headers()['location'], res.url())
+                    dest = destUrl.href
+                    if (baseUrl && dest.startsWith(baseUrl.origin)) {
+                        dest = dest.substring(baseUrl.origin.length)
                     }
-                } else if (s >= 400) {
-                    controller.abort(new AbortPageLoad())
-                    rejectResponse(res)
                 }
+            } else if (s >= 400) {
+                // for http error responses eg 404, 500
+                controller.abort(rejectedPageError(res))
             }
         }
-        page.on('response', responseListener)
+    }
+    page.on('response', responseListener)
 
-        page.goto(url.href, { waitUntil, signal: controller.signal })
-            .then((res) => {
-                if (res === null) {
-                    reject(
-                        new PageError(location, 'did not navigate', {
-                            details:
-                                '`page.goto` returned null. this could mean navigation to about:blank or the same URL with a different hash.'
-                        })
-                    )
-                } else if (res.status() >= 400) {
-                    rejectResponse(res)
-                } else {
-                    resolve(page)
-                }
+    try {
+        const res = await page.goto(url.href, { waitUntil, signal: controller.signal })
+        if (res === null) {
+            throw new PageError(location, 'did not navigate', {
+                details:
+                    '`page.goto` returned null. this could mean navigation to about:blank or the same URL with a different hash.'
             })
-            .catch((err) => {
-                if (err instanceof AbortPageLoad) return
-                const message = err instanceof Error ? err.message : 'error while navigating'
-                reject(
-                    new PageError(dest, message, {
-                        cause: err,
-                        src: location
-                    })
-                )
-            })
-            .finally(() => {
-                signal?.removeEventListener('abort', onAbort)
-            })
-    })
+        } else if (res.status() >= 400) {
+            throw rejectedPageError(res)
+        } else {
+            return page
+        }
+    } catch (err) {
+        // when loadPage is aborted, wait until page.goto settles after being aborted by its own controller
+        // before throwing the abort
+        signal?.throwIfAborted()
+
+        // this will rethrow the PageErrors thrown from the try block
+        // as well as PageErrors "thrown" via the AbortController from the response and requestfailed listeners
+        if (err instanceof PageError) {
+            throw err
+        }
+
+        // for requestfailed case
+        // since page.goto throws it own error rather than the PageError used to abort
+        if (controller.signal.aborted && controller.signal.reason instanceof PageError) {
+            const pageErr = controller.signal.reason
+            throw new PageError(pageErr.location, pageErr.title, { ...pageErr, cause: err })
+        }
+
+        // this is meant for catching unhandled errors from page.goto itself only
+        const message = err instanceof Error ? err.message : 'error while navigating'
+        throw new PageError(dest, message, {
+            cause: err,
+            src: location
+        })
+    } finally {
+        signal?.removeEventListener('abort', onAbort)
+    }
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -186,6 +186,9 @@ export async function processPage(location: string, pageOptions: PageOptions, en
             if (err instanceof PageError || err instanceof FatalError) {
                 throw err
             }
+            // rethrow abort reason if aborted
+            signal?.throwIfAborted()
+
             const info = err instanceof Error ? `: [${err.name}] ${err.message}` : ''
             throw new PageError(dest, 'failed to write pdf' + info, { cause: err, src: location })
         } finally {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -203,3 +203,87 @@ describe('throw on fail', () => {
         await expect(promise).rejects.toThrow('Failed to load')
     }, 10000)
 })
+
+describe('throw on fail logs', () => {
+    let integration: AstroIntegration
+    let logger: Logger
+    const root = new URL('./fixtures/integration/', import.meta.url)
+    const cacheDir = new URL('./node_modules/.astro/', root)
+    const cachePath = fileURLToPath(cacheDir)
+    const outDir = new URL('./dist', root)
+    const outPath = fileURLToPath(outDir)
+
+    beforeAll(async () => {
+        if (existsSync(outPath)) {
+            await rm(outPath, { recursive: true })
+        }
+        // "build" site
+        await cp(fileURLToPath(new URL('public', root)), outPath, { recursive: true })
+
+        if (existsSync(cachePath)) {
+            await rm(cachePath, { recursive: true })
+        }
+        await mkdir(cachePath, { recursive: true })
+
+        integration = pdf({
+            pages: {
+                'https://example.com/not/a/real/page.php': {
+                    throwOnFail: true
+                },
+                'https://example.com': true
+            },
+            throwErrors: false
+        })
+
+        logger = makeLogger()
+        await integration.hooks['astro:config:done']!({
+            config: {
+                root,
+                cacheDir
+            } as AstroConfig,
+            setAdapter: () => {
+                throw new Error('unimplemented')
+            },
+            injectTypes: () => {
+                throw new Error('unimplemented')
+            },
+            buildOutput: 'static',
+            logger
+        })
+        await integration.hooks['astro:build:done']!({
+            pages: [],
+            dir: outDir,
+            logger,
+            assets: new Map()
+        })
+    }, 10000)
+
+    test('logs failed pages', () => {
+        console.log(logger.debug.mock.calls)
+        console.log(logger.info.mock.calls)
+        console.log(logger.error.mock.calls)
+        expect(logger.error).toHaveBeenCalledWith('Failed to generate 2 files')
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('PageError: Failed to load `https://example.com/not/a/real/page.php`: 404\n')
+        )
+        expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/^✖︎ Failed after \d+ms./))
+    })
+
+    test('does not info log when error thrown', () => {
+        expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('https://example.com'))
+    })
+
+    test('logs page load aborted', () => {
+        expect(logger.debug).toHaveBeenCalledWith(
+            expect.stringContaining('page load aborted for https://example.com/' + '\n' + 'Caused by:')
+        )
+        expect(logger.debug).not.toHaveBeenCalledWith(
+            expect.stringContaining('page load aborted for https://example.com/not/a/real/page.php')
+        )
+    })
+
+    test('closes all pages', () => {
+        expect(logger.debug).toHaveBeenCalledWith('page closed for `https://example.com/not/a/real/page.php`')
+        expect(logger.debug).toHaveBeenCalledWith('page closed for `https://example.com/`')
+    })
+})

--- a/test/load-page.test.ts
+++ b/test/load-page.test.ts
@@ -88,7 +88,11 @@ describe('load page', () => {
         const location = 'https://fake-gxcskbrl.example.com/page.html'
         const fn = loadPage(location, undefined, page, 'networkidle0')
         const start = Date.now()
-        await expect(fn).rejects.toThrowError(new PageError(location, 'net::ERR_NAME_NOT_RESOLVED'))
+        await expect(fn).rejects.toThrowError(
+            new PageError(location, 'net::ERR_NAME_NOT_RESOLVED', {
+                cause: new Error('net::ERR_NAME_NOT_RESOLVED at ' + location)
+            })
+        )
         expect(Date.now() - start).toBeLessThan(1400)
     })
 


### PR DESCRIPTION
fixed a race condition where `page.close()` is called before `page.goto(...)` completes when there is an error in the page load which can cause the page to never close.

fixed an issue where a page load error with `throwOnFail: true` would get logged by other pages due to the way AbortController was used. the correct behaviour is for errors to only be logged if not thrown.

changed the way concurrent page processing is done to ensure that all processing can run cleanup code when a page throws an error with `throwOnFail: true`. this ensures all the other Puppeteer pages will still be closed properly.

added tests to inspect the logging behaviour with `throwOnFail: true`