### PR TITLE
use pnpm for changset publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
               uses: changesets/action@v1
               with:
                   version: pnpm run version
-                  publish: npx changeset publish
+                  publish: pnpm changeset publish
                   commit: 'chore: release'
                   title: '[changesets] release'
               env:


### PR DESCRIPTION
use `pnpm` instead of `npx` for running `changset publish` to adhere to the `devEngines.packageManager` policy