### PR TITLE
fix package publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "devEngines": {
         "packageManager": {
             "name": "pnpm",
-            "onFail": "error"
+            "onFail": "warn"
         }
     },
     "packageManager": "pnpm@11.7.0"


### PR DESCRIPTION
temporarily set `devEngines.packageManager.onFail` to `warn` instead of `error`. this fix is required to allow `changeset publish` to run as it uses `npm info` and possibly other `npm` commands.

this change can be reverted once `@changsets/cli` v3 is released as it will consistently use `pnpm`. (see [changesets/2097](https://github.com/changesets/changesets/pull/2097))

